### PR TITLE
TXMA-147 Add Cross account functionality between Event processing and…

### DIFF
--- a/event-processor/sam/audit-template.yml
+++ b/event-processor/sam/audit-template.yml
@@ -9,11 +9,16 @@ Parameters:
       - build
       - staging
       - production
+      - integration
     Default: build
-    Description: "The current environment for deployment (e.g. build, stage, prod, etc.)"
+    Description: "The current environment for deployment (e.g. build, staging, production, etc.)"
   EventProcessorStackName:
     Type: String
     Default: "di-txma-ep-build"
+    Description: "Event Processor Stack Name"
+  EventProcessorSNSTopicARN:
+    Type: String
+    Default: "arn:aws:sns:eu-west-2:248098332657:EventProcessorSNSTopic-build"
     Description: "The ARN for the event processor accounts SNS service"
 
 Resources:
@@ -42,9 +47,7 @@ Resources:
   DeliveryStreamSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      TopicArn:
-        Fn::ImportValue:
-          !Sub "${EventProcessorStackName}-SnsArn"
+      TopicArn: !Ref EventProcessorSNSTopicARN
       Endpoint: !GetAtt AuditDeliveryStream.Arn
       Protocol: firehose
       SubscriptionRoleArn: !GetAtt SNSTopicSubscriptionRole.Arn

--- a/event-processor/sam/config/samconfig-audit.toml
+++ b/event-processor/sam/config/samconfig-audit.toml
@@ -1,0 +1,57 @@
+version=0.1
+[default.deploy.parameters]
+stack_name = "di-txma-audit-build"
+profile="di-dev-audit-admin"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+tags = "project=\"di-txma-audit\" stage=\"build\""
+parameter_overrides=[
+    "Environment=build",
+    "EventProcessorStackName=di-txma-ep-build",
+    "EventProcessorSNSTopicARN=arn:aws:sns:eu-west-2:248098332657:EventProcessorSNSTopic-build"
+]
+
+[build.deploy.parameters]
+stack_name = "di-txma-audit-build"
+profile="di-dev-audit-admin"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+tags = "project=\"di-txma-audit\" stage=\"build\""
+parameter_overrides=[
+    "Environment=build",
+    "EventProcessorStackName=di-txma-ep-build",
+    "EventProcessorSNSTopicARN=arn:aws:sns:eu-west-2:248098332657:EventProcessorSNSTopic-build"
+]
+
+[staging.deploy.parameters]
+stack_name = "di-txma-audit-staging"
+profile="di-dev-audit-admin"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+tags = "project=\"di-txma-audit\" stage=\"staging\""
+parameter_overrides=[
+    "Environment=staging",
+    "EventProcessorStackName=di-txma-ep-staging"
+]
+
+[production.deploy.parameters]
+stack_name = "di-txma-audit-production"
+profile="di-dev-audit-admin"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+tags = "project=\"di-txma-audit\" stage=\"production\""
+parameter_overrides=[
+    "Environment=production",
+    "EventProcessorStackName=di-txma-ep-production"
+]
+
+[integration.deploy.parameters]
+stack_name = "di-txma-audit-integration"
+profile="di-dev-audit-admin"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+tags = "project=\"di-txma-audit\" stage=\"integration\""
+parameter_overrides=[
+    "Environment=integration",
+    "EventProcessorStackName=di-txma-ep-integration"
+]

--- a/event-processor/sam/config/samconfig-ep.toml
+++ b/event-processor/sam/config/samconfig-ep.toml
@@ -1,0 +1,45 @@
+version=0.1
+[default.deploy.parameters]
+stack_name = "di-txma-ep-build"
+profile="di-dev-event-processing-admin"
+region = "eu-west-2"
+tags = "project=\"di-txma-event_processor\" stage=\"build\""
+parameter_overrides=[
+    "Environment=build"
+]
+
+[build.deploy.parameters]
+stack_name = "di-txma-ep-build"
+profile="di-dev-event-processing-admin"
+region = "eu-west-2"
+tags = "project=\"di-txma-event_processor\" stage=\"build\""
+parameter_overrides=[
+    "Environment=build"
+]
+
+[staging.deploy.parameters]
+stack_name = "di-txma-ep-staging"
+profile="di-dev-event-processing-admin"
+region = "eu-west-2"
+tags = "project=\"di-txma-event_processor\" stage=\"staging\""
+parameter_overrides=[
+    "Environment=staging"
+]
+
+[production.deploy.parameters]
+stack_name = "di-txma-ep-production"
+profile="di-dev-event-processing-admin"
+region = "eu-west-2"
+tags = "project=\"di-txma-event_processor\" stage=\"production\""
+parameter_overrides=[
+    "Environment=production"
+]
+
+[integration.deploy.parameters]
+stack_name = "di-txma-ep-integration"
+profile="di-dev-event-processing-admin"
+region = "eu-west-2"
+tags = "project=\"di-txma-event_processor\" stage=\"integration\""
+parameter_overrides=[
+    "Environment=integration"
+]

--- a/event-processor/sam/event-processor-template.yml
+++ b/event-processor/sam/event-processor-template.yml
@@ -9,8 +9,9 @@ Parameters:
       - build
       - staging
       - production
+      - integration
     Default: build
-    Description: "The current environment for deployment (e.g. build, stage, prod, etc.)"
+    Description: "The current environment for deployment (e.g. build, staging, production, etc.)"
 
 Resources:
   epSNSTopic:
@@ -20,9 +21,23 @@ Resources:
         - EnvironmentName: !Ref Environment
     Type: "AWS::SNS::Topic"
 
-  # No subscriptions yet
-
-  # No policies yet
+  SNSSubscribePolicy:
+    Type: "AWS::SNS::TopicPolicy"
+    Properties:
+      PolicyDocument:
+        Id: SNSSubscribePolicy
+        Version: 2012-10-17
+        Statement:
+          - Sid: SNSSubscribePolicy-1
+            Effect: Allow
+            Action:
+              - 'sns:Subscribe'
+            Principal:
+                AWS:
+                  - "arn:aws:iam::725018305812:root"
+            Resource: !Ref epSNSTopic
+      Topics:
+      - !Ref epSNSTopic
 
 Outputs:
   epSNSTopicARN:

--- a/event-processor/sam/run-sam-deploy.sh
+++ b/event-processor/sam/run-sam-deploy.sh
@@ -2,7 +2,6 @@
 
 #Parameters
 environment=${environment:-build}
-profile=${school:-di-dev-admin}
 
 while [ $# -gt 0 ]; do
 
@@ -12,14 +11,14 @@ while [ $# -gt 0 ]; do
         if [[ ${param} == "environment" ]]; then
           case "$2" in
 
-            build | staging | production)
+            build | staging | production | integration)
                 echo "Environment is valid"
               ;;
 
             *)
                 echo "unexpected environment name."
                 echo "Please provide one of the following: "
-                echo "build, staging, production"
+                echo "build, staging, production, integration"
 
                 exit 1
               ;;
@@ -35,12 +34,14 @@ while [ $# -gt 0 ]; do
 done
 
 echo "Environment: $environment";
-echo "profile: $profile";
 
 alias sam='sam.cmd'
 
-sam deploy -t event-processor-template.yml --parameter-overrides Environment="$environment" --profile "$profile" --stack-name "di-txma-ep-${environment}" --region "eu-west-2"
+##Currently we need to run these individually and manually take the AccountNumber of the Audit account and ARN for the SNS queue and use it in the respective toml files.
+##Currently we are looking into using secrets manager to provide a means of sharing values between stacks in different accounts.
 
-sam deploy -t audit-template.yml --parameter-overrides Environment="$environment" EventProcessorStackName="di-txma-ep-${environment}" --profile "$profile" --stack-name "di-txma-audit-${environment}" --region "eu-west-2" --capabilities CAPABILITY_IAM
+#sam deploy --template-file event-processor-template.yml --config-file config/samconfig-ep.toml --config-env "$environment"
+
+#sam deploy --template-file audit-template.yml --config-file config/samconfig-audit.toml --config-env "$environment"
 
 $SHELL


### PR DESCRIPTION
… Audit accounts.

I have updated the files to create the two stacks on separate accounts. This has been tested end to end and confirmed.

The configuration has been updated to run as much as possible from environment defined config in the toml files.

We now need to run the sam commands in run-sam-deploy.sh separately as we have a dependency between the two. We have options to get around this (Secrets manager or a Lambda Lookup for example) but this has been left with the dev platform team for now.