### PR TITLE
Add lifecycle config to audit template so files are automatically arc…

### DIFF
--- a/audit/audit-template.yml
+++ b/audit/audit-template.yml
@@ -21,6 +21,13 @@ Parameters:
 Resources:
   MessageBatchBucket:
     Type: AWS::S3::Bucket
+    LifecycleConfiguration:
+      Rules:
+        - Id: AuditGlacierRule
+          Status: Enabled
+          Transitions:
+            - TransitionInDays: 90
+              StorageClass: GLACIER
 
   AuditDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream


### PR DESCRIPTION
…hived after 90 days.

The audit template has been updated to include a transition rule for the existing S3 bucket for files older than 90 days.