### PR TITLE
TMA-198 infrastructure for splunk

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -205,7 +205,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt KBVLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -349,7 +349,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt KBVAddressLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -493,7 +493,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt KBVFraudLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -637,7 +637,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt IPVLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -781,7 +781,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt IPVPassLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -925,7 +925,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt SPOTLambdaAccessRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -1942,7 +1942,7 @@ Resources:
       PackageType: Zip
       Handler: app.handler
       Runtime: nodejs14.x
-      Timeout: 90
+      Timeout: 30
       Role: !GetAtt ObfuscationFunctionRole.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -1968,7 +1968,7 @@ Resources:
 #      PackageType: Zip
 #      Handler: app.handler
 #      Runtime: nodejs14.x
-#      Timeout: 90
+#      Timeout: 30
 #      Events:
 #        FraudBucket:
 #          Type: S3


### PR DESCRIPTION
Match function timeouts to the CRI queue timeouts due to a hard requirement on the event mappings between the two resources