### PR TITLE
TMA-198 Update Event Processing Lambda to Send to SNS from in code

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -178,9 +178,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'sns:Publish'
-            Resource: !Sub
-              - 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${topicName}'
-              - topicName: !GetAtt epSNSTopic.TopicName
+            Resource: !Ref epSNSTopic
           - Effect: Allow
             Action:
               - 'kms:Decrypt'
@@ -207,6 +205,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt KBVLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -215,20 +216,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  KBVEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - KBVEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref KBVEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   KBVEventProcessorUnknownFieldsErrorMetric:
     DependsOn:
@@ -351,6 +338,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt KBVAddressLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -359,20 +349,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  KBVAddressEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - KBVAddressEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref KBVAddressEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   KBVAddressEventProcessorUnknownFieldsErrorMetric:
     DependsOn:
@@ -495,6 +471,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt KBVFraudLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -503,20 +482,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  KBVFraudEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - KBVFraudEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref KBVFraudEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   KBVFraudEventProcessorUnknownFieldsErrorMetric:
     DependsOn:
@@ -639,6 +604,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt IPVLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -648,19 +616,6 @@ Resources:
         EntryPoints:
           - app.ts
 
-  IPVEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - IPVEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref IPVEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   IPVEventProcessorUnknownFieldsErrorMetric:
     DependsOn:
@@ -783,6 +738,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt IPVPassLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -791,20 +749,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  IPVPassEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - IPVPassEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref IPVPassEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   IPVPassEventProcessorUnknownFieldsErrorMetric:
     DependsOn:
@@ -927,6 +871,9 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt SPOTLambdaAccessRole.Arn
+      Environment:
+        Variables:
+          topicArn: !Ref epSNSTopic
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -935,20 +882,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  SPOTEventInvokeConfig:
-    DependsOn:
-      - SNSPublishPolicy
-      - SPOTEventProcessorFunction
-    Type: AWS::Lambda::EventInvokeConfig
-    Properties:
-      FunctionName: !Ref SPOTEventProcessorFunction
-      Qualifier: "$LATEST"
-      MaximumEventAgeInSeconds: 600
-      MaximumRetryAttempts: 2
-      DestinationConfig:
-        OnSuccess:
-          Destination: !Ref epSNSTopic
 
   SPOTEventProcessorUnknownFieldsErrorMetric:
     DependsOn:

--- a/event-processing/event-processor/package.json
+++ b/event-processing/event-processor/package.json
@@ -33,5 +33,8 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.5"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1136.0"
   }
 }

--- a/event-processing/event-processor/services/sns-service.ts
+++ b/event-processing/event-processor/services/sns-service.ts
@@ -1,0 +1,29 @@
+import { config, SNS } from 'aws-sdk';
+
+export class SnsService {
+    static async publishMessageToSNS(message: string, topicArn: string | undefined): Promise<void> {
+        console.log(`Topic ARN: ${topicArn}`);
+
+        config.update({ region: process.env.AWS_REGION });
+
+        const params = {
+            Message: message,
+            TopicArn: topicArn,
+        };
+
+        const sns = new SNS({ apiVersion: '2010-03-31' });
+
+        const publishTextPromise = sns.publish(params).promise();
+
+        await publishTextPromise
+            .then((data) => {
+                console.log(`Message ${params.Message} send sent to the topic ${params.TopicArn}`);
+                console.log('MessageID is ' + data.MessageId);
+            })
+            .catch((err) => {
+                console.error(err, err.stack);
+            });
+
+        return;
+    }
+}

--- a/event-processing/event-processor/services/sns-service.ts
+++ b/event-processing/event-processor/services/sns-service.ts
@@ -17,7 +17,6 @@ export class SnsService {
 
         await publishTextPromise
             .then((data) => {
-                console.log(`Message ${params.Message} send sent to the topic ${params.TopicArn}`);
                 console.log('MessageID is ' + data.MessageId);
             })
             .catch((err) => {

--- a/event-processing/event-processor/services/validation-service.ts
+++ b/event-processing/event-processor/services/validation-service.ts
@@ -7,7 +7,7 @@ import { IUserUnknownFields } from '../models/user-unknown-fields.interface';
 import { RequiredFieldsEnum } from '../enums/required-fields.enum';
 import { IUnknownFieldDetails } from '../models/unknown-field-details.interface';
 
-export class validationService {
+export class ValidationService {
     static async validateSQSRecord(record: SQSRecord): Promise<IValidationResponse> {
         const message = record.body;
 

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -59,10 +59,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"\",\"request_id\":\"\",\"session_id\":\"\",\"client_id\":\"\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"persistent_session_id\":\"\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully stringifies an SQS event', async () => {
@@ -107,10 +106,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully stringifies multiple events', async () => {
@@ -156,10 +154,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
@@ -207,11 +204,10 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[WARN] UNKNOWN FIELDS\n{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","timestamp":"1609462861","message":"Unknown fields in message.","unknownFields":[{"key":"new_unknown_field","fieldName":"AuditEvent"},{"key":"unknown_user_field","fieldName":"User"}]}');
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('successfully populates missing formatted timestamp fields', async () => {
@@ -256,10 +252,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-01T01:01:01.000Z\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('logs an error when validation fails on event name', async () => {
@@ -328,11 +323,10 @@ describe('Unit test for app handler', function () {
 
         await handler(sqsEvent);
 
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"","timestamp":"1609462861","requiredField":"event_name","message":"event_name is a required field."}]}')
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
@@ -407,11 +401,10 @@ describe('Unit test for app handler', function () {
 
         await handler(sqsEvent);
 
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","requiredField":"timestamp","message":"timestamp is a required field."}]}')
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -3,16 +3,38 @@ import { handler } from '../../app';
 import { TestHelper } from './test-helper';
 import { IAuditEvent } from '../../models/audit-event';
 import { AuditEvent as UnknownAuditEvent } from '../../tests/test-events/unknown-audit-event';
+import {SNS} from "aws-sdk";
+import {MockedFunction} from "ts-jest";
+
+jest.mock('aws-sdk', () => {
+    const mockSNSInstance = {
+        publish: jest.fn().mockReturnThis(),
+        promise: jest.fn(),
+    };
+    const mockSNS = jest.fn(() => mockSNSInstance);
+
+    return {
+        SNS: mockSNS,
+        config: {
+            update: jest.fn()
+        }
+    };
+});
 
 describe('Unit test for app handler', function () {
-    let consoleWarningMock: jest.SpyInstance;
+    let consoleMock: jest.SpyInstance;
+    let sns: SNS;
 
     beforeEach(() => {
-        consoleWarningMock = jest.spyOn(global.console, 'log');
+        consoleMock = jest.spyOn(global.console, 'log');
+        sns = new SNS();
+
+        process.env.topicArn = 'SOME-SNS-TOPIC';
     });
 
     afterEach(() => {
-       consoleWarningMock.mockRestore();
+       consoleMock.mockRestore();
+       jest.clearAllMocks();
     });
 
     it('accepts a bare minimum payload and stringifies', async () => {
@@ -25,11 +47,22 @@ describe('Unit test for app handler', function () {
             event_name: 'AUTHENTICATION_ATTEMPT',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage));
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(result).toEqual(expectedResult);
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
+        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"\",\"request_id\":\"\",\"session_id\":\"\",\"client_id\":\"\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"persistent_session_id\":\"\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('successfully stringifies an SQS event', async () => {
@@ -62,11 +95,22 @@ describe('Unit test for app handler', function () {
             persistent_session_id: 'some session id',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage));
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(result).toEqual(expectedResult);
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
+        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('successfully stringifies multiple events', async () => {
@@ -100,11 +144,22 @@ describe('Unit test for app handler', function () {
             persistent_session_id: 'some session id',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage), 2);
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(result).toEqual(expectedResult);
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
+        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
@@ -140,13 +195,23 @@ describe('Unit test for app handler', function () {
             new_unknown_field: "an unknown field"
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEventWithUnknownField(exampleMessage));
 
-        const result = await handler(sqsEvent);
-        
-        expect(result).toEqual(expectedResult);
-        expect(consoleWarningMock).toHaveBeenCalledTimes(1);
-        expect(consoleWarningMock).toHaveBeenCalledWith('[WARN] UNKNOWN FIELDS\n{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","timestamp":"1609462861","message":"Unknown fields in message.","unknownFields":[{"key":"new_unknown_field","fieldName":"AuditEvent"},{"key":"unknown_user_field","fieldName":"User"}]}');
+        await handler(sqsEvent);
+
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
+        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, '[WARN] UNKNOWN FIELDS\n{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","timestamp":"1609462861","message":"Unknown fields in message.","unknownFields":[{"key":"new_unknown_field","fieldName":"AuditEvent"},{"key":"unknown_user_field","fieldName":"User"}]}');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
     });
 
     it('successfully populates missing formatted timestamp fields', async () => {
@@ -179,11 +244,22 @@ describe('Unit test for app handler', function () {
             persistent_session_id: 'some session id',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage));
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(result).toEqual(expectedResult);
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
+        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-01T01:01:01.000Z\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('logs an error when validation fails on event name', async () => {
@@ -243,16 +319,26 @@ describe('Unit test for app handler', function () {
             persistent_session_id: 'some session id',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage), 2);
         const sqsEventWithInvalidMessage = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleInvalidMessage));
 
         sqsEvent.Records.push(...sqsEventWithInvalidMessage.Records)
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(consoleWarningMock).toHaveBeenCalledTimes(1);
-        expect(consoleWarningMock).toHaveBeenCalledWith('[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"","timestamp":"1609462861","requiredField":"event_name","message":"event_name is a required field."}]}')
-        expect(result).toEqual(expectedResult);
+        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"","timestamp":"1609462861","requiredField":"event_name","message":"event_name is a required field."}]}')
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
     });
 
     it('logs an error when validation fails on timestamp', async () => {
@@ -312,15 +398,25 @@ describe('Unit test for app handler', function () {
             persistent_session_id: 'some session id',
         };
 
+        (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
+
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage), 2);
         const sqsEventWithInvalidMessage = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleInvalidMessage));
 
         sqsEvent.Records.push(...sqsEventWithInvalidMessage.Records)
 
-        const result = await handler(sqsEvent);
+        await handler(sqsEvent);
 
-        expect(consoleWarningMock).toHaveBeenCalledTimes(1);
-        expect(consoleWarningMock).toHaveBeenCalledWith('[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","requiredField":"timestamp","message":"timestamp is a required field."}]}')
-        expect(result).toEqual(expectedResult);
+        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","requiredField":"timestamp","message":"timestamp is a required field."}]}')
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
+        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(sns.publish).toHaveBeenCalledWith(
+            {
+                Message: expectedResult,
+                TopicArn: 'SOME-SNS-TOPIC'
+            }
+        );
     });
 });

--- a/event-processing/event-processor/yarn.lock
+++ b/event-processing/event-processor/yarn.lock
@@ -971,6 +971,21 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+aws-sdk@^2.1136.0:
+  version "2.1136.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1136.0.tgz#d103aed0313af2c254a2dbd54823af8057c7a0b9"
+  integrity sha512-cuXPB1lNoiK/oNTAN+Bud2Pp8/PvY7erL2DYPVN2zsk2nh9e8VG3yldf6KcEO6mm4q/FgZc4X6Zq+fOyuBY/wA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 babel-jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.1.tgz#a1bf8d61928edfefd21da27eb86a695bfd691444"
@@ -1037,6 +1052,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.0.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1086,6 +1106,15 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -1618,6 +1647,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1890,6 +1924,16 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
@@ -1982,6 +2026,11 @@ is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+isarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2435,6 +2484,11 @@ jest@^27.5.0:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2841,10 +2895,20 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2925,6 +2989,16 @@ safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^5.0.1:
   version "5.0.1"
@@ -3238,6 +3312,19 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
 v8-compile-cache-lib@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -3354,6 +3441,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
The following PR is to resolve an issue with the Event Invoke Configuration currently used to deliver messages to SNS from our event processor Lambda. The resultant messages created by using the event invoke config contain AWS event data that we do not want to include in our auditing and analysis streams. Currently, there is no means by which to specify RAW message delivery as with other services. As such, we have removed the Event Invoke configuration and instead use the AWS SDK to call SNS from within the Lambda.