### PR TITLE
TMA-236 prevent empty message delivery to SNS

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -126,6 +126,34 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/SNSKMSKey"
       TargetKeyId: !Ref SNSKMSKey
 
+  LambdaKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource:
+              - "*"
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'kms:Decrypt'
+            Resource: '*'
+
+  LambdaKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}/${Environment}/LambdaKMSKey"
+      TargetKeyId: !Ref LambdaKMSKey
+
   epSNSTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -208,6 +236,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -341,6 +370,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -474,6 +504,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -607,6 +638,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -741,6 +773,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -874,6 +907,7 @@ Resources:
       Environment:
         Variables:
           topicArn: !Ref epSNSTopic
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:

--- a/event-processing/event-processor/app.ts
+++ b/event-processing/event-processor/app.ts
@@ -30,18 +30,20 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         );
     }
 
-    await SnsService.publishMessageToSNS(
-        JSON.stringify(
-            validationResponses
-                .filter((response: IValidationResponse) => {
-                    return response.isValid;
-                })
-                .map((validationResponse: IValidationResponse) => {
-                    return validationResponse.message;
-                }),
-        ),
-        process.env.topicArn,
-    );
+    if (validationResponses.some((response: IValidationResponse) => response.isValid)) {
+        await SnsService.publishMessageToSNS(
+            JSON.stringify(
+                validationResponses
+                    .filter((response: IValidationResponse) => {
+                        return response.isValid;
+                    })
+                    .map((validationResponse: IValidationResponse) => {
+                        return validationResponse.message;
+                    }),
+            ),
+            process.env.topicArn,
+        );
+    }
 
     return;
 };

--- a/event-processing/event-processor/services/sns-service.ts
+++ b/event-processing/event-processor/services/sns-service.ts
@@ -17,7 +17,6 @@ export class SnsService {
 
         await publishTextPromise
             .then((data) => {
-                console.log(`Message ${params.Message} send sent to the topic ${params.TopicArn}`);
                 console.log('MessageID is ' + data.MessageId);
             })
             .catch((err) => {

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -59,10 +59,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"\",\"request_id\":\"\",\"session_id\":\"\",\"client_id\":\"\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"persistent_session_id\":\"\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully stringifies an SQS event', async () => {
@@ -107,10 +106,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully stringifies multiple events', async () => {
@@ -156,10 +154,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
@@ -207,11 +204,10 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[WARN] UNKNOWN FIELDS\n{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","timestamp":"1609462861","message":"Unknown fields in message.","unknownFields":[{"key":"new_unknown_field","fieldName":"AuditEvent"},{"key":"unknown_user_field","fieldName":"User"}]}');
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
     });
 
     it('successfully populates missing formatted timestamp fields', async () => {
@@ -256,10 +252,9 @@ describe('Unit test for app handler', function () {
                 TopicArn: 'SOME-SNS-TOPIC'
             }
         );
-        expect(consoleMock).toHaveBeenCalledTimes(3);
+        expect(consoleMock).toHaveBeenCalledTimes(2);
         expect(consoleMock).toHaveBeenNthCalledWith(1, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(2, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-01T01:01:01.000Z\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(2, 'MessageID is 1');
     });
 
     it('logs an error when validation fails on event name', async () => {
@@ -328,11 +323,10 @@ describe('Unit test for app handler', function () {
 
         await handler(sqsEvent);
 
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"","timestamp":"1609462861","requiredField":"event_name","message":"event_name is a required field."}]}')
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
@@ -407,11 +401,10 @@ describe('Unit test for app handler', function () {
 
         await handler(sqsEvent);
 
-        expect(consoleMock).toHaveBeenCalledTimes(4);
+        expect(consoleMock).toHaveBeenCalledTimes(3);
         expect(consoleMock).toHaveBeenNthCalledWith(1, '[ERROR] VALIDATION ERROR\n{"requireFieldErrors":[{"sqsResourceName":"arn:aws:sqs:us-west-2:123456789012:SQSQueue","eventId":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","eventName":"AUTHENTICATION_ATTEMPT","requiredField":"timestamp","message":"timestamp is a required field."}]}')
         expect(consoleMock).toHaveBeenNthCalledWith(2, 'Topic ARN: SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(3, 'Message [{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"},{\"event_id\":\"66258f3e-82fc-4f61-9ba0-62424e1f06b4\",\"request_id\":\"43143-233Ds-2823-283-dj299j1\",\"session_id\":\"c222c1ec\",\"client_id\":\"some-client\",\"timestamp\":1609462861,\"timestamp_formatted\":\"2021-01-23T15:43:21.842\",\"event_name\":\"AUTHENTICATION_ATTEMPT\",\"user\":{\"transaction_id\":\"a52f6f87\",\"email\":\"foo@bar.com\",\"phone\":\"07711223344\",\"ip_address\":\"100.100.100.100\"},\"platform\":{\"xray_trace_id\":\"24727sda4192\"},\"restricted\":{\"experian_ref\":\"DSJJSEE29392\"},\"extensions\":{\"response\":\"Authentication successful\"},\"persistent_session_id\":\"some session id\"}] send sent to the topic SOME-SNS-TOPIC');
-        expect(consoleMock).toHaveBeenNthCalledWith(4, 'MessageID is 1');
+        expect(consoleMock).toHaveBeenNthCalledWith(3, 'MessageID is 1');
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,


### PR DESCRIPTION
The following fixes an issue where if no valid messages exist it will still send an Empty message to SNS.