### PR TITLE
TMA-236 If an invalid event is received (such as an event missing the…

### DIFF
--- a/event-processing/event-processor/app.ts
+++ b/event-processing/event-processor/app.ts
@@ -30,18 +30,20 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         );
     }
 
-    await SnsService.publishMessageToSNS(
-        JSON.stringify(
-            validationResponses
-                .filter((response: IValidationResponse) => {
-                    return response.isValid;
-                })
-                .map((validationResponse: IValidationResponse) => {
-                    return validationResponse.message;
-                }),
-        ),
-        process.env.topicArn,
-    );
+    if (validationResponses.some((response: IValidationResponse) => response.isValid)) {
+        await SnsService.publishMessageToSNS(
+            JSON.stringify(
+                validationResponses
+                    .filter((response: IValidationResponse) => {
+                        return response.isValid;
+                    })
+                    .map((validationResponse: IValidationResponse) => {
+                        return validationResponse.message;
+                    }),
+            ),
+            process.env.topicArn,
+        );
+    }
 
     return;
 };


### PR DESCRIPTION
… timestamp field) a validation error will be raised and an empty message pushed to SNS.

The following wraps the publish logic in a logical check for the presence of valid records before attempting to send (otherwise an empty message is generated)