### PR TITLE
TMA-260 Include missing permissions for FireHose to CloudWatch. This …

### DIFF
--- a/audit/audit-template.yml
+++ b/audit/audit-template.yml
@@ -53,6 +53,35 @@ Globals:
       - x86_64
 
 Resources:
+  LogsKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource:
+              - "*"
+          - Effect: "Allow"
+            Principal:
+              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource:
+              - "*"
+            Condition:
+              ArnLike:
+                "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
   MessageBucketLogsBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -117,6 +146,21 @@ Resources:
               - TransitionInDays: 90
                 StorageClass: GLACIER
 
+  FirehoseLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
+      LogGroupName: "/aws/firehose"
+      RetentionInDays: 7
+
+  FirehoseLogStream:
+    DependsOn:
+      - FirehoseLogGroup
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref FirehoseLogGroup
+      LogStreamName: "audit"
+
   AuditDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
     DependsOn:
@@ -137,6 +181,10 @@ Resources:
           SizeInMBs: 128
         CompressionFormat: "GZIP"
         RoleARN: !GetAtt DeliveryStreamRole.Arn
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref FirehoseLogGroup
+          LogStreamName: !Ref FirehoseLogStream
 
   DeliveryStreamSubscription:
     Type: AWS::SNS::Subscription
@@ -188,6 +236,13 @@ Resources:
                 - - 'arn:aws:s3:::'
                   - !Ref MessageBatchBucket
                   - '*'
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:PutLogEvents'
+              - 'logs:CreateLogStream'
+            Resource:
+              - '*'
 
   SNSTopicSubscriptionRole:
     Type: AWS::IAM::Role

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1414,6 +1414,13 @@ Resources:
               - 'lambda:GetFunctionConfiguration'
             Resource:
               - !Sub "${ObfuscationFunction.Arn}*"
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:PutLogEvents'
+              - 'logs:CreateLogStream'
+            Resource:
+              - '*'
 
   FraudDeliveryStreamTestPolicy:
     DependsOn:
@@ -1501,6 +1508,13 @@ Resources:
               - 'lambda:GetFunctionConfiguration'
             Resource:
               - !Sub "${ObfuscationFunction.Arn}*"
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:PutLogEvents'
+              - 'logs:CreateLogStream'
+            Resource:
+              - '*'
 
   CyberDeliveryStreamTestPolicy:
     DependsOn:
@@ -1588,6 +1602,13 @@ Resources:
               - 'lambda:GetFunctionConfiguration'
             Resource:
               - !Sub "${ObfuscationFunction.Arn}*"
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:PutLogEvents'
+              - 'logs:CreateLogStream'
+            Resource:
+              - '*'
 
   PerformanceDeliveryStreamTestPolicy:
     DependsOn:
@@ -1711,6 +1732,10 @@ Resources:
               SizeInMBs: 128
             CompressionFormat: "GZIP"
             RoleARN: !GetAtt FraudDeliveryStreamRole.Arn
+            CloudWatchLoggingOptions:
+              Enabled: true
+              LogGroupName: !Ref FirehoseLogGroup
+              LogStreamName: !Ref FraudFirehoseLogStream
             ProcessingConfiguration:
               Enabled: true
               Processors:
@@ -1783,6 +1808,10 @@ Resources:
               SizeInMBs: 128
             CompressionFormat: "GZIP"
             RoleARN: !GetAtt CyberDeliveryStreamRole.Arn
+            CloudWatchLoggingOptions:
+              Enabled: true
+              LogGroupName: !Ref FirehoseLogGroup
+              LogStreamName: !Ref CyberFirehoseLogStream
             ProcessingConfiguration:
               Enabled: true
               Processors:
@@ -1855,6 +1884,10 @@ Resources:
               SizeInMBs: 128
             CompressionFormat: "GZIP"
             RoleARN: !GetAtt PerformanceDeliveryStreamRole.Arn
+            CloudWatchLoggingOptions:
+              Enabled: true
+              LogGroupName: !Ref FirehoseLogGroup
+              LogStreamName: !Ref PerformanceFirehoseLogStream
             ProcessingConfiguration:
               Enabled: true
               Processors:


### PR DESCRIPTION
…was preventing the cloudwatch logging being enabled on deployment between cloudwatch and firehose.

Update dev and build environment S3 destination to enable logging. This wasn't configured.

Also, enable logging on the Audit delivery stream.