### PR TITLE
TMA-249 Provide Obfuscation Secret

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -153,46 +153,6 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/LambdaKMSKey"
       TargetKeyId: !Ref LambdaKMSKey
 
-  HMACKeyKMSKey:
-    Type: AWS::KMS::Key
-    Properties:
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - "kms:*"
-            Resource:
-              - "*"
-          - Effect: "Allow"
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - "kms:Decrypt"
-              - "kms:Encrypt"
-              - 'kms:GenerateDataKey*'
-              - 'kms:DescribeKey'
-            Resource:
-              - "{{resolve:ssm:AuthAccountARN}}"
-          - Effect: "Allow"
-            Principal:
-              Service: "lambda.amazonaws.com"
-            Action:
-              - "kms:Decrypt"
-              - "kms:Encrypt"
-              - 'kms:GenerateDataKey*'
-              - 'kms:DescribeKey'
-            Resource: '*'
-
-  HMACKeyKMSKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !Sub "alias/${AWS::StackName}/${Environment}/HMACKeyKMSKey"
-      TargetKeyId: !Ref HMACKeyKMSKey
-
   epSNSTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -2037,8 +1997,6 @@ Resources:
       RetentionInDays: 7
 
   ObfuscationFunction:
-    DependsOn:
-      - ObfuscationHMACSecret
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: "ObfuscationFunction"
@@ -2050,7 +2008,7 @@ Resources:
       Role: !GetAtt ObfuscationFunctionRole.Arn
       Environment:
         Variables:
-          secretArn: !Ref ObfuscationHMACSecret
+          secretArn: "{{resolve:ssm:HMACSecretArn}}"
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
@@ -2060,33 +2018,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
-
-  ObfuscationHMACSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: "HMAC Secret to encrypt data using the obfuscation function"
-      GenerateSecretString:
-        ExcludeLowercase: false
-        ExcludeNumbers: false
-        ExcludePunctuation: true
-        ExcludeUppercase: false
-        IncludeSpace: false
-        PasswordLength: 32
-      KmsKeyId: !Ref HMACKeyKMSKey
-      Name: "ObfuscationHMACSecret"
-      Tags:
-        -
-          Key: BillingEnvironment
-          Value: !Ref Environment
-        -
-          Key: BillingOrganization
-          Value: "GDS"
-        -
-          Key: BillingProgramme
-          Value: "One Login for Government"
-        -
-          Key: BillingProject
-          Value: "TxMA"
 
 #  ReIngestLogGroup:
 #    Type: AWS::Logs::LogGroup

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -2019,6 +2019,47 @@ Resources:
         EntryPoints:
           - app.ts
 
+  AuthHMACAccessRole:
+    Type: AWS::IAM::Role
+    Condition: IsProductionOrStaging
+    Properties:
+      PermissionsBoundary: !If
+        - SetPermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - "{{resolve:ssm:AuthAccountARN}}"
+            Action:
+              - sts:AssumeRole
+
+  AuthHMACAccessPolicy:
+    DependsOn:
+      - AuthHMACAccessRole
+    Type: AWS::IAM::Policy
+    Condition: IsProductionOrStaging
+    Properties:
+      Roles:
+        - !Ref AuthHMACAccessRole
+      PolicyName: auth_hmac_access_policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:GetSecretValue'
+            Resource:
+              - "{{resolve:ssm:HMACSecretArn}}"
+          - Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+            Resource:
+              - "{{resolve:ssm:HMACKeyKMSKeyArn}}"
+
 #  ReIngestLogGroup:
 #    Type: AWS::Logs::LogGroup
 #    Properties:
@@ -2072,3 +2113,9 @@ Resources:
 #        Sourcemap: true
 #        EntryPoints:
 #          - app.ts
+
+Outputs:
+  AuthHMACAccessRoleARN:
+    Description: Access Role for Auth to be able to read the HMAC Secret value
+    Value: !GetAtt AuthHMACAccessRole.Arn
+    Condition: IsProductionOrStaging

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -186,10 +186,6 @@ Resources:
               - 'kms:GenerateDataKey*'
               - 'kms:DescribeKey'
             Resource: '*'
-            Condition:
-              ForAnyValue:ArnEquals:
-                "aws:PrincipalArn":
-                  - !GetAtt ObfuscationFunction.Arn
 
   HMACKeyKMSKeyAlias:
     Type: AWS::KMS::Alias

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -2005,6 +2005,8 @@ Resources:
       RetentionInDays: 7
 
   ObfuscationFunction:
+    DependsOn:
+      - ObfuscationHMACSecret
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: "ObfuscationFunction"

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -142,8 +142,7 @@ Resources:
               - "*"
           - Effect: "Allow"
             Principal:
-              Service:
-                - lambda.amazonaws.com
+              Service: "lambda.amazonaws.com"
             Action:
               - 'kms:Decrypt'
             Resource: '*'
@@ -153,6 +152,50 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/LambdaKMSKey"
       TargetKeyId: !Ref LambdaKMSKey
+
+  HMACKeyKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource:
+              - "*"
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:Decrypt"
+              - "kms:Encrypt"
+              - 'kms:GenerateDataKey*'
+              - 'kms:DescribeKey'
+            Resource:
+              - "{{resolve:ssm:AuthAccountARN}}"
+          - Effect: "Allow"
+            Principal:
+              Service: "lambda.amazonaws.com"
+            Action:
+              - "kms:Decrypt"
+              - "kms:Encrypt"
+              - 'kms:GenerateDataKey*'
+              - 'kms:DescribeKey'
+            Resource: '*'
+            Condition:
+              ForAnyValue:ArnEquals:
+                "aws:PrincipalArn":
+                  - !GetAtt ObfuscationFunction.Arn
+
+  HMACKeyKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}/${Environment}/HMACKeyKMSKey"
+      TargetKeyId: !Ref HMACKeyKMSKey
 
   epSNSTopic:
     Type: AWS::SNS::Topic
@@ -1971,6 +2014,10 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 30
       Role: !GetAtt ObfuscationFunctionRole.Arn
+      Environment:
+        Variables:
+          secretArn: !Ref ObfuscationHMACSecret
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild
       BuildProperties:
@@ -1979,6 +2026,35 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
+
+  ObfuscationHMACSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: "HMAC Secret to encrypt data using the obfuscation function"
+      GenerateSecretString:
+        ExcludeLowercase: false
+        ExcludeNumbers: false
+        ExcludePunctuation: true
+        ExcludeUppercase: false
+        IncludeSpace: false
+        PasswordLength: 32
+      KmsKeyId: !Ref HMACKeyKMSKey
+      Name: "ObfuscationHMACSecret"
+      ReplicaRegions:
+        - ReplicaRegion
+      Tags:
+        -
+          Key: BillingEnvironment
+          Value: !Ref Environment
+        -
+          Key: BillingOrganization
+          Value: "GDS"
+        -
+          Key: BillingProgramme
+          Value: "One Login for Government"
+        -
+          Key: BillingProject
+          Value: "TxMA"
 
 #  ReIngestLogGroup:
 #    Type: AWS::Logs::LogGroup

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -2042,8 +2042,6 @@ Resources:
         PasswordLength: 32
       KmsKeyId: !Ref HMACKeyKMSKey
       Name: "ObfuscationHMACSecret"
-      ReplicaRegions:
-        - ReplicaRegion
       Tags:
         -
           Key: BillingEnvironment

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -2008,7 +2008,7 @@ Resources:
       Role: !GetAtt ObfuscationFunctionRole.Arn
       Environment:
         Variables:
-          secretArn: "{{resolve:ssm:HMACSecretArn}}"
+          SECRET_ARN: "{{resolve:ssm:HMACSecretArn}}"
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     Metadata: # Manage esbuild properties
       BuildMethod: esbuild


### PR DESCRIPTION
WHAT:

Provide the HMAC secret as a parameter for the Obfuscation function.

Provide a Role for Auth to be able to assume to read the secret value for the HMAC.

WHY:

We need to provide a secret used for encryption within the obfuscation function. Secrets manager provides this functionality without us needing to expose the secret or store externally to AWS.

Auth need to use the same HMAC secret for their encryption in order to avoid issues with multiple sources pushing data using different encryption secrets.