### PR TITLE
TMA-269 ADR payload update

### DIFF
--- a/event-processing/event-processor/models/audit-event-unknown-fields.ts
+++ b/event-processing/event-processor/models/audit-event-unknown-fields.ts
@@ -8,12 +8,15 @@ export class AuditEventUnknownFields {
     static fromAuditMessage(object: any, unknown_fields: Map<string, unknown>): IAuditEventUnknownFields {
         return {
             event_id: isSet(object.event_id) ? String(object.event_id) : '',
-            request_id: isSet(object.request_id) ? String(object.request_id) : '',
+            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id)
+                ? String(object.govuk_signin_journey_id)
+                : '',
             session_id: isSet(object.session_id) ? String(object.session_id) : '',
             client_id: isSet(object.client_id) ? String(object.client_id) : '',
             timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
             timestamp_formatted: isSet(object.timestamp_formatted) ? String(object.timestamp_formatted) : '',
             event_name: isSet(object.event_name) ? String(object.event_name) : '',
+            component_id: isSet(object.component_id) ? String(object.component_id) : '',
             user: isSet(object.user) ? object.user : undefined,
             platform: isSet(object.platform) ? object.platform : undefined,
             restricted: isSet(object.restricted) ? object.restricted : undefined,

--- a/event-processing/event-processor/models/audit-event-unknown-fields.ts
+++ b/event-processing/event-processor/models/audit-event-unknown-fields.ts
@@ -22,7 +22,6 @@ export class AuditEventUnknownFields {
             restricted: isSet(object.restricted) ? object.restricted : undefined,
             extensions: isSet(object.extensions) ? object.extensions : undefined,
             persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
-            service_name: isSet(object.service_name) ? object.service_name : '',
             _unknownFields: unknown_fields,
         };
     }

--- a/event-processing/event-processor/models/audit-event.ts
+++ b/event-processing/event-processor/models/audit-event.ts
@@ -3,12 +3,13 @@ import { IUserUnknownFields, UserUnknownFields } from './user-unknown-fields.int
 
 export interface IAuditEvent {
     event_id?: string;
-    request_id?: string;
+    govuk_signin_journey_id?: string;
     session_id?: string;
     client_id?: string;
     timestamp: number;
     timestamp_formatted?: string;
     event_name: string;
+    component_id: string;
     user?: IAuditEventUserMessage | undefined;
     platform?: unknown | undefined;
     restricted?: unknown | undefined;
@@ -27,12 +28,13 @@ export interface IAuditEventUserMessage {
 function createBaseAuditEvent(): IAuditEvent {
     return {
         event_id: '',
-        request_id: '',
+        govuk_signin_journey_id: '',
         session_id: '',
         client_id: '',
         timestamp: 0,
         timestamp_formatted: '',
         event_name: '',
+        component_id: '',
         user: undefined,
         platform: undefined,
         restricted: undefined,
@@ -52,8 +54,8 @@ export class AuditEvent {
                 case 'event_id':
                     event.event_id = jsonObject[value];
                     break;
-                case 'request_id':
-                    event.request_id = jsonObject[value];
+                case 'govuk_signin_journey_id':
+                    event.govuk_signin_journey_id = jsonObject[value];
                     break;
                 case 'session_id':
                     event.session_id = jsonObject[value];
@@ -69,6 +71,9 @@ export class AuditEvent {
                     break;
                 case 'event_name':
                     event.event_name = jsonObject[value];
+                    break;
+                case 'component_id':
+                    event.component_id = jsonObject[value];
                     break;
                 case 'user':
                     event.user = AuditEventUserMessage.fromObject(jsonObject[value]);
@@ -102,18 +107,21 @@ export class AuditEvent {
     static toJSON(message: IAuditEvent): object {
         const obj: any = {};
         message.event_id !== undefined && (obj.event_id = message.event_id);
-        message.request_id !== undefined && (obj.request_id = message.request_id);
+        message.govuk_signin_journey_id !== undefined &&
+            (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
         message.session_id !== undefined && (obj.session_id = message.session_id);
         message.client_id !== undefined && (obj.client_id = message.client_id);
         message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
         message.timestamp_formatted !== undefined && (obj.timestamp_formatted = message.timestamp_formatted);
         message.event_name !== undefined && (obj.event_name = message.event_name);
+        message.component_id !== undefined && (obj.component_id = message.component_id);
         message.user !== undefined &&
             (obj.user = message.user ? AuditEventUserMessage.toJSON(message.user) : undefined);
         message.platform !== undefined && (obj.platform = message.platform ? message.platform : undefined);
         message.restricted !== undefined && (obj.restricted = message.restricted ? message.restricted : undefined);
         message.extensions !== undefined && (obj.extensions = message.extensions ? message.extensions : undefined);
         message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
+        message.service_name !== undefined && (obj.service_name = message.service_name);
         return obj;
     }
 }

--- a/event-processing/event-processor/models/audit-event.ts
+++ b/event-processing/event-processor/models/audit-event.ts
@@ -15,7 +15,6 @@ export interface IAuditEvent {
     restricted?: unknown | undefined;
     extensions?: unknown | undefined;
     persistent_session_id?: string;
-    service_name?: string;
 }
 
 export interface IAuditEventUserMessage {
@@ -40,7 +39,6 @@ function createBaseAuditEvent(): IAuditEvent {
         restricted: undefined,
         extensions: undefined,
         persistent_session_id: '',
-        service_name: '',
     };
 }
 
@@ -90,9 +88,6 @@ export class AuditEvent {
                 case 'persistent_session_id':
                     event.persistent_session_id = jsonObject[value];
                     break;
-                case 'service_name':
-                    event.service_name = jsonObject[value];
-                    break;
                 default:
                     unknown_fields.set(value, jsonObject[value]);
                     break;
@@ -121,7 +116,6 @@ export class AuditEvent {
         message.restricted !== undefined && (obj.restricted = message.restricted ? message.restricted : undefined);
         message.extensions !== undefined && (obj.extensions = message.extensions ? message.extensions : undefined);
         message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
-        message.service_name !== undefined && (obj.service_name = message.service_name);
         return obj;
     }
 }

--- a/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
+++ b/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
@@ -14,7 +14,6 @@ export interface AuditEvent {
     restricted: unknown | undefined;
     extensions: unknown | undefined;
     persistent_session_id: string;
-    service_name?: string;
     new_unknown_field: string;
 }
 
@@ -42,7 +41,6 @@ export class AuditEvent {
             restricted: isSet(object.restricted) ? object.restricted : undefined,
             extensions: isSet(object.extensions) ? object.extensions : undefined,
             persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
-            service_name: isSet(object.service_name) ? String(object.service_name) : '',
             new_unknown_field: isSet(object.new_unknown_field) ? String(object.new_unknown_field) : '',
         };
     }
@@ -66,7 +64,6 @@ export class AuditEvent {
         message.extensions !== undefined &&
             (obj.extensions = message.extensions ? message.extensions : undefined);
         message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
-        message.service_name !== undefined && (obj.service_name = message.service_name);
         message.new_unknown_field !== undefined && (obj.new_unknown_field = message.new_unknown_field);
         return obj;
     }

--- a/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
+++ b/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
@@ -2,17 +2,19 @@
 /* istanbul ignore file */ 
 export interface AuditEvent {
     event_id: string;
-    request_id: string;
+    govuk_signin_journey_id: string;
     session_id: string;
     client_id: string;
     timestamp: number;
     timestamp_formatted: string;
     event_name: string;
+    component_id: string;
     user: IAuditEventUserMessage | undefined;
     platform: unknown | undefined;
     restricted: unknown | undefined;
     extensions: unknown | undefined;
     persistent_session_id: string;
+    service_name?: string;
     new_unknown_field: string;
 }
 
@@ -28,17 +30,19 @@ export class AuditEvent {
     static fromJSON(object: any): AuditEvent {
         return {
             event_id: isSet(object.event_id) ? String(object.event_id) : '',
-            request_id: isSet(object.request_id) ? String(object.request_id) : '',
+            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id) ? String(object.govuk_signin_journey_id) : '',
             session_id: isSet(object.session_id) ? String(object.session_id) : '',
             client_id: isSet(object.client_id) ? String(object.client_id) : '',
             timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
             timestamp_formatted: isSet(object.timestamp_formatted) ? String(object.timestamp_formatted) : '',
             event_name: isSet(object.event_name) ? String(object.event_name) : '',
+            component_id: isSet(object.component_id) ? String(object.component_id) : '',
             user: isSet(object.user) ? AuditEventUserMessage.fromJSON(object.user) : undefined,
             platform: isSet(object.platform) ? object.platform : undefined,
             restricted: isSet(object.restricted) ? object.restricted : undefined,
             extensions: isSet(object.extensions) ? object.extensions : undefined,
             persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
+            service_name: isSet(object.service_name) ? String(object.service_name) : '',
             new_unknown_field: isSet(object.new_unknown_field) ? String(object.new_unknown_field) : '',
         };
     }
@@ -46,12 +50,13 @@ export class AuditEvent {
     static toJSON(message: AuditEvent): unknown {
         const obj: any = {};
         message.event_id !== undefined && (obj.event_id = message.event_id);
-        message.request_id !== undefined && (obj.request_id = message.request_id);
+        message.govuk_signin_journey_id !== undefined && (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
         message.session_id !== undefined && (obj.session_id = message.session_id);
         message.client_id !== undefined && (obj.client_id = message.client_id);
         message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
         message.timestamp_formatted !== undefined && (obj.timestamp_formatted = message.timestamp_formatted);
         message.event_name !== undefined && (obj.event_name = message.event_name);
+        message.component_id !== undefined && (obj.component_id = message.component_id);
         message.user !== undefined &&
             (obj.user = message.user ? AuditEventUserMessage.toJSON(message.user) : undefined);
         message.platform !== undefined &&
@@ -61,6 +66,7 @@ export class AuditEvent {
         message.extensions !== undefined &&
             (obj.extensions = message.extensions ? message.extensions : undefined);
         message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
+        message.service_name !== undefined && (obj.service_name = message.service_name);
         message.new_unknown_field !== undefined && (obj.new_unknown_field = message.new_unknown_field);
         return obj;
     }

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -42,14 +42,15 @@ describe('Unit test for app handler', function () {
     });
 
     afterEach(() => {
-       consoleMock.mockRestore();
-       jest.clearAllMocks();
+        consoleMock.mockRestore();
+        jest.clearAllMocks();
     });
 
     it('does not send a message if the Lambda errors', async () => {
         const exampleMessage: IAuditEvent = {
             timestamp: 1609464356546575462861, //Incorrect timestamp value
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234'
         };
 
         const sqsEvent = TestHelper.createSQSEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage));
@@ -73,12 +74,13 @@ describe('Unit test for app handler', function () {
 
     it('accepts a bare minimum payload and stringifies', async () => {
         const expectedResult =
-            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","request_id":"","session_id":"","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","persistent_session_id":""}';
+            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","govuk_signin_journey_id":"","session_id":"","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","persistent_session_id":"","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
@@ -101,16 +103,17 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies an SQS event', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -118,13 +121,13 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
@@ -148,16 +151,17 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies multiple events', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -165,13 +169,13 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
@@ -204,16 +208,17 @@ describe('Unit test for app handler', function () {
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: UnknownAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -223,13 +228,13 @@ describe('Unit test for app handler', function () {
             },
             platform: {
 
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
             new_unknown_field: "an unknown field"
@@ -255,16 +260,17 @@ describe('Unit test for app handler', function () {
 
     it('successfully populates missing formatted timestamp fields', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -272,13 +278,13 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
@@ -302,16 +308,17 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on event name', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -319,25 +326,26 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
 
         const exampleInvalidMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: '',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -345,13 +353,13 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
@@ -389,16 +397,17 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on timestamp', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","request_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -406,25 +415,26 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };
 
         const exampleInvalidMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            request_id: '43143-233Ds-2823-283-dj299j1',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 0,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: '1234',
             user: {
                 transaction_id: 'a52f6f87',
                 email: 'foo@bar.com',
@@ -432,13 +442,13 @@ describe('Unit test for app handler', function () {
                 ip_address: '100.100.100.100',
             },
             platform: {
-               xray_trace_id: '24727sda4192',
+                xray_trace_id: '24727sda4192',
             },
             restricted: {
-               experian_ref: 'DSJJSEE29392',
+                experian_ref: 'DSJJSEE29392',
             },
             extensions: {
-               response: 'Authentication successful',
+                response: 'Authentication successful',
             },
             persistent_session_id: 'some session id',
         };

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -74,7 +74,7 @@ describe('Unit test for app handler', function () {
 
     it('accepts a bare minimum payload and stringifies', async () => {
         const expectedResult =
-            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","govuk_signin_journey_id":"","session_id":"","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","persistent_session_id":"","service_name":""}';
+            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","govuk_signin_journey_id":"","session_id":"","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","persistent_session_id":""}';
 
         const exampleMessage: IAuditEvent = {
             timestamp: 1609462861,
@@ -103,7 +103,7 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies an SQS event', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
@@ -151,7 +151,7 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies multiple events', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
@@ -208,7 +208,7 @@ describe('Unit test for app handler', function () {
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: UnknownAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
@@ -260,7 +260,7 @@ describe('Unit test for app handler', function () {
 
     it('successfully populates missing formatted timestamp fields', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
@@ -308,7 +308,7 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on event name', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
@@ -397,7 +397,7 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on timestamp', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id","service_name":""}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',

--- a/event-processing/obfuscation/models/audit-event.ts
+++ b/event-processing/obfuscation/models/audit-event.ts
@@ -11,7 +11,6 @@ export interface IAuditEvent {
     platform?: unknown | undefined;
     restricted?: unknown | undefined;
     extensions?: unknown | undefined;
-    service_name?: string;
     persistent_session_id?: string;
 }
 
@@ -37,7 +36,6 @@ function createBaseAuditEvent(): IAuditEvent {
         restricted: undefined,
         extensions: undefined,
         persistent_session_id: '',
-        service_name: '',
     };
 }
 
@@ -45,7 +43,6 @@ export class AuditEvent {
     static fromJSONString(object: string): IAuditEvent {
         const event = createBaseAuditEvent();
         const jsonObject = JSON.parse(object);
-        const unknown_fields = new Map<string, unknown>();
         for (const value in jsonObject) {
             switch (value) {
                 case 'event_id':
@@ -87,9 +84,6 @@ export class AuditEvent {
                 case 'persistent_session_id':
                     event.persistent_session_id = jsonObject[value];
                     break;
-                case 'service_name':
-                    event.service_name = jsonObject[value];
-                    break;
             }
         }
         return event;
@@ -102,7 +96,6 @@ function createBaseAuditEventUserMessage(): IAuditEventUserMessage {
 
 export class AuditEventUserMessage {
     static fromObject(object: any): IAuditEventUserMessage {
-        const unknown_fields = new Map<string, any>();
         const user = createBaseAuditEventUserMessage();
         for (const value in object) {
             switch (value) {

--- a/event-processing/obfuscation/models/audit-event.ts
+++ b/event-processing/obfuscation/models/audit-event.ts
@@ -1,15 +1,17 @@
 export interface IAuditEvent {
     event_id?: string;
-    request_id?: string;
+    govuk_signin_journey_id?: string;
     session_id?: string;
     client_id?: string;
     timestamp: number;
     timestamp_formatted?: string;
     event_name: string;
+    component_id: string;
     user?: IAuditEventUserMessage | undefined;
     platform?: unknown | undefined;
     restricted?: unknown | undefined;
     extensions?: unknown | undefined;
+    service_name?: string;
     persistent_session_id?: string;
 }
 
@@ -23,17 +25,19 @@ export interface IAuditEventUserMessage {
 function createBaseAuditEvent(): IAuditEvent {
     return {
         event_id: '',
-        request_id: '',
+        govuk_signin_journey_id: '',
         session_id: '',
         client_id: '',
         timestamp: 0,
         timestamp_formatted: '',
         event_name: '',
+        component_id: '',
         user: undefined,
         platform: undefined,
         restricted: undefined,
         extensions: undefined,
         persistent_session_id: '',
+        service_name: '',
     };
 }
 
@@ -47,8 +51,8 @@ export class AuditEvent {
                 case 'event_id':
                     event.event_id = jsonObject[value];
                     break;
-                case 'request_id':
-                    event.request_id = jsonObject[value];
+                case 'govuk_signin_journey_id':
+                    event.govuk_signin_journey_id = jsonObject[value];
                     break;
                 case 'session_id':
                     event.session_id = jsonObject[value];
@@ -65,6 +69,9 @@ export class AuditEvent {
                 case 'event_name':
                     event.event_name = jsonObject[value];
                     break;
+                case 'component_id':
+                    event.component_id = jsonObject[value];
+                    break;
                 case 'user':
                     event.user = AuditEventUserMessage.fromObject(jsonObject[value]);
                     break;
@@ -79,6 +86,9 @@ export class AuditEvent {
                     break;
                 case 'persistent_session_id':
                     event.persistent_session_id = jsonObject[value];
+                    break;
+                case 'service_name':
+                    event.service_name = jsonObject[value];
                     break;
             }
         }

--- a/event-processing/obfuscation/models/obfuscated-event.ts
+++ b/event-processing/obfuscation/models/obfuscated-event.ts
@@ -1,4 +1,4 @@
-import { IAuditEvent } from "./audit-event";
+import { IAuditEvent } from './audit-event';
 
 export interface IObfuscatedEvent {
     timestamp: number;
@@ -11,7 +11,7 @@ export class ObfuscatedEvent {
         return {
             timestamp: event.timestamp,
             timestamp_formatted: event.timestamp_formatted,
-            event_name: event.event_name
-        }
+            event_name: event.event_name,
+        };
     }
 }

--- a/event-processing/obfuscation/tests/unit/test-helper.ts
+++ b/event-processing/obfuscation/tests/unit/test-helper.ts
@@ -1,20 +1,17 @@
 /* istanbul ignore file */
-import {
-    FirehoseTransformationEvent,
-    FirehoseTransformationEventRecord
-} from 'aws-lambda';
+import { FirehoseTransformationEvent, FirehoseTransformationEventRecord } from 'aws-lambda';
 import { IAuditEvent } from '../../models/audit-event';
 
 export class TestHelper {
-
     static exampleMessage: IAuditEvent = {
         event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-        request_id: '43143-233Ds-2823-283-dj299j1',
+        govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
         session_id: 'c222c1ec',
         client_id: 'some-client',
         timestamp: 1609462861,
         timestamp_formatted: '2021-01-23T15:43:21.842',
         event_name: 'AUTHENTICATION_ATTEMPT',
+        component_id: '1234',
         user: {
             transaction_id: 'a52f6f87',
             email: 'foo@bar.com',
@@ -31,29 +28,30 @@ export class TestHelper {
             response: 'Authentication successful',
         },
         persistent_session_id: 'some session id',
+        service_name: '',
     };
 
-    private static firehoseTransformationEvent : FirehoseTransformationEvent = {
-        invocationId: "bb5d7530-f7b7-44aa-bc0f-01b76248fbb8",
+    private static firehoseTransformationEvent: FirehoseTransformationEvent = {
+        invocationId: 'bb5d7530-f7b7-44aa-bc0f-01b76248fbb8',
         deliveryStreamArn: 'arn:aws:firehose:eu-west-2:123456789012:Firehose',
         region: 'eu-west-2',
-        records: []
-    }
+        records: [],
+    };
 
-    private static firehoseTransformationEventRecord : FirehoseTransformationEventRecord = {
-        recordId: "7041e12f-c772-41e4-a05f-8bf25cc6f4bb",
+    private static firehoseTransformationEventRecord: FirehoseTransformationEventRecord = {
+        recordId: '7041e12f-c772-41e4-a05f-8bf25cc6f4bb',
         approximateArrivalTimestamp: 1520621625029,
         /** Base64 encoded */
-        data: ""
-    }
+        data: '',
+    };
 
     static createFirehoseEventWithEncodedMessage(message: string, numberOfRecords = 1): FirehoseTransformationEvent {
         const event = JSON.parse(JSON.stringify(this.firehoseTransformationEvent));
-        const encodedMessage : string = Buffer.from(message).toString('base64')
-        
+        const encodedMessage: string = Buffer.from(message).toString('base64');
+
         for (let i = 0; i < numberOfRecords; i++) {
-            let record = this.firehoseTransformationEventRecord
-            record.data = encodedMessage
+            const record = this.firehoseTransformationEventRecord;
+            record.data = encodedMessage;
             event.records.push(record);
         }
 
@@ -61,7 +59,7 @@ export class TestHelper {
     }
 
     static encodeAuditEventArray(message: unknown): string {
-        let messages : unknown[] = []
+        const messages: unknown[] = [];
         messages.push(message);
         return JSON.stringify(messages);
     }

--- a/event-processing/obfuscation/tests/unit/test-helper.ts
+++ b/event-processing/obfuscation/tests/unit/test-helper.ts
@@ -11,7 +11,7 @@ export class TestHelper {
         timestamp: 1609462861,
         timestamp_formatted: '2021-01-23T15:43:21.842',
         event_name: 'AUTHENTICATION_ATTEMPT',
-        component_id: '1234',
+        component_id: 'AUTH',
         user: {
             transaction_id: 'a52f6f87',
             email: 'foo@bar.com',
@@ -28,7 +28,6 @@ export class TestHelper {
             response: 'Authentication successful',
         },
         persistent_session_id: 'some session id',
-        service_name: '',
     };
 
     private static firehoseTransformationEvent: FirehoseTransformationEvent = {


### PR DESCRIPTION
Due to the upcoming changes to the ADR: https://github.com/alphagov/digital-identity-architecture/pull/175, 
we need to update our Lambda models to reflect the updated data dictionary.

This includes adding the new field 'component_id' updating the 'request_id' field to be 'govuk_signin_journey_id' and correctly handling the 'service_name' field.