### PR TITLE
TMA-252 SNS message attributes

### DIFF
--- a/event-processing/event-processor/app.ts
+++ b/event-processing/event-processor/app.ts
@@ -4,6 +4,7 @@ import { SnsService } from './services/sns-service';
 import { IRequiredFieldError } from './models/required-field-error.interface';
 import { ValidationException } from './exceptions/validation-exception';
 import { EnrichmentService } from './services/enrichment-service';
+import { IAuditEvent } from './models/audit-event';
 
 export const handler = async (event: SQSEvent): Promise<void> => {
     for (const record of event.Records) {
@@ -20,8 +21,8 @@ export const handler = async (event: SQSEvent): Promise<void> => {
                     ),
             );
         } else {
-            const message = await EnrichmentService.enrichValidationResponse(validationResponse);
-            await SnsService.publishMessageToSNS(JSON.stringify(message), process.env.topicArn);
+            const message: IAuditEvent = await EnrichmentService.enrichValidationResponse(validationResponse);
+            await SnsService.publishMessageToSNS(message, process.env.topicArn);
         }
     }
 

--- a/event-processing/event-processor/services/enrichment-service.ts
+++ b/event-processing/event-processor/services/enrichment-service.ts
@@ -1,16 +1,16 @@
-import { AuditEvent, IAuditEvent } from '../models/audit-event';
+import { IAuditEvent } from '../models/audit-event';
 import { IAuditEventUnknownFields } from '../models/audit-event-unknown-fields';
 import { IValidationResponse } from '../models/validation-response.interface';
 import { randomUUID } from 'crypto';
 
 export class EnrichmentService {
-    static async enrichValidationResponse(response: IValidationResponse): Promise<object> {
+    static async enrichValidationResponse(response: IValidationResponse): Promise<IAuditEvent> {
         const message = response.message;
 
         return this.enrichEventMessage(message);
     }
 
-    private static async enrichEventMessage(message: object): Promise<object> {
+    private static async enrichEventMessage(message: object): Promise<IAuditEvent> {
         const eventMessage = message as IAuditEventUnknownFields;
 
         if (!eventMessage.timestamp_formatted) {
@@ -21,6 +21,6 @@ export class EnrichmentService {
             eventMessage.event_id = randomUUID();
         }
 
-        return AuditEvent.toJSON(eventMessage as IAuditEvent);
+        return eventMessage;
     }
 }

--- a/event-processing/event-processor/services/sns-service.ts
+++ b/event-processing/event-processor/services/sns-service.ts
@@ -1,14 +1,22 @@
 import { config, SNS } from 'aws-sdk';
+import { IAuditEvent } from '../models/audit-event';
+import { PublishInput } from 'aws-sdk/clients/sns';
 
 export class SnsService {
-    static async publishMessageToSNS(message: string, topicArn: string | undefined): Promise<void> {
+    static async publishMessageToSNS(message: IAuditEvent, topicArn: string | undefined): Promise<void> {
         console.log(`Topic ARN: ${topicArn}`);
 
         config.update({ region: process.env.AWS_REGION });
 
-        const params = {
-            Message: message,
+        const params: PublishInput = {
+            Message: JSON.stringify(message),
             TopicArn: topicArn,
+            MessageAttributes: {
+                eventName: {
+                    DataType: 'String',
+                    StringValue: message.event_name,
+                },
+            },
         };
 
         const sns = new SNS({ apiVersion: '2010-03-31' });

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -90,7 +90,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
         expect(consoleMock).toHaveBeenCalledTimes(2);
@@ -138,7 +144,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
         expect(consoleMock).toHaveBeenCalledTimes(2);
@@ -186,13 +198,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
-            }
-        );
-        expect(sns.publish).toHaveBeenCalledWith(
-            {
-                Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
         expect(consoleMock).toHaveBeenCalledTimes(4);
@@ -244,7 +256,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
         expect(consoleMock).toHaveBeenCalledTimes(3);
@@ -292,7 +310,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
         expect(consoleMock).toHaveBeenCalledTimes(2);
@@ -375,13 +399,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
-            }
-        );
-        expect(sns.publish).toHaveBeenCalledWith(
-            {
-                Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
 
@@ -462,13 +486,13 @@ describe('Unit test for app handler', function () {
         expect(sns.publish).toHaveBeenCalledWith(
             {
                 Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
-            }
-        );
-        expect(sns.publish).toHaveBeenCalledWith(
-            {
-                Message: expectedResult,
-                TopicArn: 'SOME-SNS-TOPIC'
+                TopicArn: 'SOME-SNS-TOPIC',
+                MessageAttributes: {
+                    eventName: {
+                        DataType: 'String',
+                        StringValue: 'AUTHENTICATION_ATTEMPT',
+                    },
+                },
             }
         );
     });


### PR DESCRIPTION
Update the SNS service to populate the SNS publish input with message attributes used for filtering.

Also update to use the 'IAuditEvent' model when passing between services and use 'PublishInput' interface when defining the SNS payload