### PR TITLE
TMA-286 Provide access to secret for obfuscation role

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -2023,6 +2023,8 @@ Resources:
           - app.ts
 
   HMACSecretAuthAccessPolicy:
+    DependsOn:
+      - ObfuscationFunctionRole
     Type: AWS::SecretsManager::ResourcePolicy
     Properties:
       BlockPublicPolicy: True
@@ -2043,7 +2045,7 @@ Resources:
             Action: "secretsmanager:GetSecretValue"
             Effect: Allow
             Principal:
-              AWS: !Sub "${AWS::AccountId}"
+              AWS: !GetAtt ObfuscationFunctionRole.Arn
 
 #  ReIngestLogGroup:
 #    Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Update the secretsmanager:GetSecretValue to be for the role used by the Lambda instead of the account.