### PR TITLE
TMA-286 obfuscation cannot read secret

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1992,6 +1992,22 @@ Resources:
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
 
+  ObfuscationHmacKmsPolicy:
+    DependsOn:
+      - ObfuscationFunctionRole
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+        - !Ref ObfuscationFunctionRole
+      PolicyName: hmac_kms_policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+            Resource: "{{resolve:ssm:HMACKeyKMSKeyArn}}"
+
   ObfuscationLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
Provide policy to obfuscation role to decrypt the KMS key. It appears having the permissions applied via the key policy to all lambda services was not enough for the permissions to use the key.