### PR TITLE
TMA-320 Update docker files to set user directive (Pen testing outcome)

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -68,7 +68,11 @@ jobs:
           ECR_REPOSITORY_INTEGRATION: ${{ secrets.ECR_REPOSITORY_EVENT_PROCESSING_INTEGRATION }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./event-processing-tests/
+          docker build \
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg GIT_REPO=$GITHUB_REPOSITORY \
+            --build-arg COMMIT_SHA=$GITHUB_SHA \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./event-processing-tests/
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
@@ -120,7 +124,11 @@ jobs:
           ECR_REPOSITORY_INTEGRATION: ${{ secrets.ECR_REPOSITORY_AUDIT_INTEGRATION }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./audit-tests/
+          docker build /
+            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+            --build-arg GIT_REPO=$GITHUB_REPOSITORY \
+            --build-arg COMMIT_SHA=$GITHUB_SHA \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./audit-tests/
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG

--- a/tests/audit-tests/Dockerfile
+++ b/tests/audit-tests/Dockerfile
@@ -1,8 +1,13 @@
 FROM amazonlinux:2
 
 RUN yum install -y awscli
+RUN yum install -y shadow-utils
+RUN useradd -ms /bin/bash AutomationUser
 
 COPY run-tests.sh ./
 RUN chmod +x run-tests.sh
+RUN chown AutomationUser: ./run-tests.sh
 
-ENTRYPOINT ["/run-tests.sh"]
+USER AutomationUser
+
+ENTRYPOINT ["./run-tests.sh"]

--- a/tests/audit-tests/Dockerfile
+++ b/tests/audit-tests/Dockerfile
@@ -1,13 +1,39 @@
-FROM amazonlinux:2
+FROM amazoncorretto:11
+
+ARG BUILD_DATE
+ARG COMMIT_SHA
+ARG GIT_REPO
+
+LABEL "BUILD_DATE" = ${BUILD_DATE}
+LABEL "COMMIT_SHA" = ${COMMIT_SHA}
+LABEL "GIT_REPO" = ${GIT_REPO}
 
 RUN yum install -y awscli
 RUN yum install -y shadow-utils
+RUN yum install -y wget
+RUN yum install -y unzip
 RUN useradd -ms /bin/bash AutomationUser
 
-COPY run-tests.sh ./
+WORKDIR /home/AutomationUser
+
+# copy source code over
+COPY ./ ./
+
 RUN chmod +x run-tests.sh
 RUN chown AutomationUser: ./run-tests.sh
 
-USER AutomationUser
+#Install Gradle and dependencies
+RUN chmod +x ./gradlew
+RUN chown AutomationUser: ./gradlew
+RUN wget https://services.gradle.org/distributions/gradle-7.4.2-bin.zip -P /tmp
+RUN unzip -d /opt/gradle /tmp/gradle-*.zip
+
+ENV GRADLE_HOME=/opt/gradle/gradle-7.4.2
+ENV PATH=$PATH:$GRADLE_HOME/bin
+
+RUN echo $PATH
+RUN gradle -v
 
 ENTRYPOINT ["./run-tests.sh"]
+
+USER AutomationUser

--- a/tests/audit-tests/run-tests.sh
+++ b/tests/audit-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/tests/audit-tests/run-tests.sh
+++ b/tests/audit-tests/run-tests.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 
-#gradle clean cucumber
+#./gradlew clean test -Dcucumber.filter.tags="$environment"
 
 cat <<EOF > "$TEST_REPORT_DIR/result.json"
 [

--- a/tests/event-processing-tests/Dockerfile
+++ b/tests/event-processing-tests/Dockerfile
@@ -1,8 +1,13 @@
 FROM amazonlinux:2
 
 RUN yum install -y awscli
+RUN yum install -y shadow-utils
+RUN useradd -ms /bin/bash AutomationUser
 
 COPY run-tests.sh ./
 RUN chmod +x run-tests.sh
+RUN chown AutomationUser: ./run-tests.sh
 
-ENTRYPOINT ["/run-tests.sh"]
+USER AutomationUser
+
+ENTRYPOINT ["./run-tests.sh"]

--- a/tests/event-processing-tests/Dockerfile
+++ b/tests/event-processing-tests/Dockerfile
@@ -1,13 +1,39 @@
-FROM amazonlinux:2
+FROM amazoncorretto:11
+
+ARG BUILD_DATE
+ARG COMMIT_SHA
+ARG GIT_REPO
+
+LABEL "BUILD_DATE" = ${BUILD_DATE}
+LABEL "COMMIT_SHA" = ${COMMIT_SHA}
+LABEL "GIT_REPO" = ${GIT_REPO}
 
 RUN yum install -y awscli
 RUN yum install -y shadow-utils
+RUN yum install -y wget
+RUN yum install -y unzip
 RUN useradd -ms /bin/bash AutomationUser
 
-COPY run-tests.sh ./
+WORKDIR /home/AutomationUser
+
+# copy source code over
+COPY ./ ./
+
 RUN chmod +x run-tests.sh
 RUN chown AutomationUser: ./run-tests.sh
 
-USER AutomationUser
+#Install Gradle and dependencies
+RUN chmod +x ./gradlew
+RUN chown AutomationUser: ./gradlew
+RUN wget https://services.gradle.org/distributions/gradle-7.4.2-bin.zip -P /tmp
+RUN unzip -d /opt/gradle /tmp/gradle-*.zip
+
+ENV GRADLE_HOME=/opt/gradle/gradle-7.4.2
+ENV PATH=$PATH:$GRADLE_HOME/bin
+
+RUN echo $PATH
+RUN gradle -v
 
 ENTRYPOINT ["./run-tests.sh"]
+
+USER AutomationUser

--- a/tests/event-processing-tests/run-tests.sh
+++ b/tests/event-processing-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/tests/event-processing-tests/run-tests.sh
+++ b/tests/event-processing-tests/run-tests.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 
-#gradle clean cucumber
+#./gradlew clean test -Dcucumber.filter.tags="$environment"
 
 cat <<EOF > "$TEST_REPORT_DIR/result.json"
 [


### PR DESCRIPTION
The pen testing has resulted in the following comment made: 

_'As I am going through the findings I have noticed that the docker container seems to be running as root on di-txma-audit-main/tests/event-processing-tests/Dockerfile and di-txma-audit-main/tests/audit-tests/Dockerfile. As discussed on the call this afternoon, it is advisable to add USER directive in dockerfile config to limit privileges an application requires to run.  This way we can reduce the attack surface without (hopefully) breaking successful deployment.'_

As such, we have added a user directive to our Dockerfile.

Can we confirm this is all that is needed? I'm not a Linux/Docker expert.