### PR TITLE
TMA-339 Ipdate event fields for session_id, govuk_signin_journey_id and persistant_session_id

### DIFF
--- a/event-processing/event-processor/models/audit-event-unknown-fields.ts
+++ b/event-processing/event-processor/models/audit-event-unknown-fields.ts
@@ -8,10 +8,6 @@ export class AuditEventUnknownFields {
     static fromAuditMessage(object: any, unknown_fields: Map<string, unknown>): IAuditEventUnknownFields {
         return {
             event_id: isSet(object.event_id) ? String(object.event_id) : '',
-            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id)
-                ? String(object.govuk_signin_journey_id)
-                : '',
-            session_id: isSet(object.session_id) ? String(object.session_id) : '',
             client_id: isSet(object.client_id) ? String(object.client_id) : '',
             timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
             timestamp_formatted: isSet(object.timestamp_formatted) ? String(object.timestamp_formatted) : '',
@@ -21,7 +17,6 @@ export class AuditEventUnknownFields {
             platform: isSet(object.platform) ? object.platform : undefined,
             restricted: isSet(object.restricted) ? object.restricted : undefined,
             extensions: isSet(object.extensions) ? object.extensions : undefined,
-            persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
             _unknownFields: unknown_fields,
         };
     }

--- a/event-processing/event-processor/models/audit-event.ts
+++ b/event-processing/event-processor/models/audit-event.ts
@@ -3,8 +3,6 @@ import { IUserUnknownFields, UserUnknownFields } from './user-unknown-fields.int
 
 export interface IAuditEvent {
     event_id?: string;
-    govuk_signin_journey_id?: string;
-    session_id?: string;
     client_id?: string;
     timestamp: number;
     timestamp_formatted?: string;
@@ -14,7 +12,6 @@ export interface IAuditEvent {
     platform?: unknown | undefined;
     restricted?: unknown | undefined;
     extensions?: unknown | undefined;
-    persistent_session_id?: string;
 }
 
 export interface IAuditEventUserMessage {
@@ -22,13 +19,14 @@ export interface IAuditEventUserMessage {
     email?: string;
     phone?: string;
     ip_address: string;
+    session_id?: string;
+    persistent_session_id?: string;
+    govuk_signin_journey_id?: string;
 }
 
 function createBaseAuditEvent(): IAuditEvent {
     return {
         event_id: '',
-        govuk_signin_journey_id: '',
-        session_id: '',
         client_id: '',
         timestamp: 0,
         timestamp_formatted: '',
@@ -38,7 +36,6 @@ function createBaseAuditEvent(): IAuditEvent {
         platform: undefined,
         restricted: undefined,
         extensions: undefined,
-        persistent_session_id: '',
     };
 }
 
@@ -51,12 +48,6 @@ export class AuditEvent {
             switch (value) {
                 case 'event_id':
                     event.event_id = jsonObject[value];
-                    break;
-                case 'govuk_signin_journey_id':
-                    event.govuk_signin_journey_id = jsonObject[value];
-                    break;
-                case 'session_id':
-                    event.session_id = jsonObject[value];
                     break;
                 case 'client_id':
                     event.client_id = jsonObject[value];
@@ -85,9 +76,6 @@ export class AuditEvent {
                 case 'extensions':
                     event.extensions = jsonObject[value];
                     break;
-                case 'persistent_session_id':
-                    event.persistent_session_id = jsonObject[value];
-                    break;
                 default:
                     unknown_fields.set(value, jsonObject[value]);
                     break;
@@ -102,9 +90,6 @@ export class AuditEvent {
     static toJSON(message: IAuditEvent): object {
         const obj: any = {};
         message.event_id !== undefined && (obj.event_id = message.event_id);
-        message.govuk_signin_journey_id !== undefined &&
-            (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
-        message.session_id !== undefined && (obj.session_id = message.session_id);
         message.client_id !== undefined && (obj.client_id = message.client_id);
         message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
         message.timestamp_formatted !== undefined && (obj.timestamp_formatted = message.timestamp_formatted);
@@ -115,13 +100,20 @@ export class AuditEvent {
         message.platform !== undefined && (obj.platform = message.platform ? message.platform : undefined);
         message.restricted !== undefined && (obj.restricted = message.restricted ? message.restricted : undefined);
         message.extensions !== undefined && (obj.extensions = message.extensions ? message.extensions : undefined);
-        message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
         return obj;
     }
 }
 
 function createBaseAuditEventUserMessage(): IAuditEventUserMessage {
-    return { transaction_id: '', email: '', phone: '', ip_address: '' };
+    return {
+        transaction_id: '',
+        email: '',
+        phone: '',
+        ip_address: '',
+        session_id: '',
+        persistent_session_id: '',
+        govuk_signin_journey_id: '',
+    };
 }
 
 export class AuditEventUserMessage {
@@ -142,6 +134,15 @@ export class AuditEventUserMessage {
                 case 'ip_address':
                     user.ip_address = object.ip_address;
                     break;
+                case 'session_id':
+                    user.session_id = object.session_id;
+                    break;
+                case 'persistent_session_id':
+                    user.persistent_session_id = object.persistent_session_id;
+                    break;
+                case 'govuk_signin_journey_id':
+                    user.govuk_signin_journey_id = object.govuk_signin_journey_id;
+                    break;
                 default:
                     unknown_fields.set(value, object[value]);
                     break;
@@ -159,6 +160,10 @@ export class AuditEventUserMessage {
         message.email !== undefined && (obj.email = message.email);
         message.phone !== undefined && (obj.phone = message.phone);
         message.ip_address !== undefined && (obj.ip_address = message.ip_address);
+        message.session_id !== undefined && (obj.session_id = message.session_id);
+        message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
+        message.govuk_signin_journey_id !== undefined &&
+            (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
         return obj;
     }
 }

--- a/event-processing/event-processor/models/user-unknown-fields.interface.ts
+++ b/event-processing/event-processor/models/user-unknown-fields.interface.ts
@@ -3,6 +3,9 @@ export interface IUserUnknownFields {
     email: string;
     phone: string;
     ip_address: string;
+    session_id: string;
+    persistent_session_id: string;
+    govuk_signin_journey_id: string;
     _unknownFields: Map<string, unknown>;
 }
 
@@ -13,6 +16,11 @@ export class UserUnknownFields {
             email: isSet(object.email) ? String(object.email) : '',
             phone: isSet(object.phone) ? String(object.phone) : '',
             ip_address: isSet(object.ip_address) ? String(object.ip_address) : '',
+            session_id: isSet(object.session_id) ? String(object.session_id) : '',
+            persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
+            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id)
+                ? String(object.govuk_signin_journey_id)
+                : '',
             _unknownFields: unknown_fields,
         };
     }

--- a/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
+++ b/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
@@ -19,9 +19,9 @@ export interface IAuditEventUserMessage {
     email: string;
     phone: string;
     ip_address: string;
-    session_id?: string;
-    persistent_session_id?: string;
-    govuk_signin_journey_id?: string;
+    session_id: string;
+    persistent_session_id: string;
+    govuk_signin_journey_id: string;
     unknown_user_field: string;
 }
 

--- a/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
+++ b/event-processing/event-processor/tests/test-events/unknown-audit-event.ts
@@ -2,8 +2,6 @@
 /* istanbul ignore file */ 
 export interface AuditEvent {
     event_id: string;
-    govuk_signin_journey_id: string;
-    session_id: string;
     client_id: string;
     timestamp: number;
     timestamp_formatted: string;
@@ -13,7 +11,6 @@ export interface AuditEvent {
     platform: unknown | undefined;
     restricted: unknown | undefined;
     extensions: unknown | undefined;
-    persistent_session_id: string;
     new_unknown_field: string;
 }
 
@@ -22,6 +19,9 @@ export interface IAuditEventUserMessage {
     email: string;
     phone: string;
     ip_address: string;
+    session_id?: string;
+    persistent_session_id?: string;
+    govuk_signin_journey_id?: string;
     unknown_user_field: string;
 }
 
@@ -29,8 +29,6 @@ export class AuditEvent {
     static fromJSON(object: any): AuditEvent {
         return {
             event_id: isSet(object.event_id) ? String(object.event_id) : '',
-            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id) ? String(object.govuk_signin_journey_id) : '',
-            session_id: isSet(object.session_id) ? String(object.session_id) : '',
             client_id: isSet(object.client_id) ? String(object.client_id) : '',
             timestamp: isSet(object.timestamp) ? Number(object.timestamp) : 0,
             timestamp_formatted: isSet(object.timestamp_formatted) ? String(object.timestamp_formatted) : '',
@@ -40,7 +38,6 @@ export class AuditEvent {
             platform: isSet(object.platform) ? object.platform : undefined,
             restricted: isSet(object.restricted) ? object.restricted : undefined,
             extensions: isSet(object.extensions) ? object.extensions : undefined,
-            persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
             new_unknown_field: isSet(object.new_unknown_field) ? String(object.new_unknown_field) : '',
         };
     }
@@ -48,8 +45,6 @@ export class AuditEvent {
     static toJSON(message: AuditEvent): unknown {
         const obj: any = {};
         message.event_id !== undefined && (obj.event_id = message.event_id);
-        message.govuk_signin_journey_id !== undefined && (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
-        message.session_id !== undefined && (obj.session_id = message.session_id);
         message.client_id !== undefined && (obj.client_id = message.client_id);
         message.timestamp !== undefined && (obj.timestamp = Math.round(message.timestamp));
         message.timestamp_formatted !== undefined && (obj.timestamp_formatted = message.timestamp_formatted);
@@ -63,7 +58,6 @@ export class AuditEvent {
             (obj.restricted = message.restricted ? message.restricted : undefined);
         message.extensions !== undefined &&
             (obj.extensions = message.extensions ? message.extensions : undefined);
-        message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
         message.new_unknown_field !== undefined && (obj.new_unknown_field = message.new_unknown_field);
         return obj;
     }
@@ -76,6 +70,9 @@ export class AuditEventUserMessage {
             email: isSet(object.email) ? String(object.email) : '',
             phone: isSet(object.phone) ? String(object.phone) : '',
             ip_address: isSet(object.ip_address) ? String(object.ip_address) : '',
+            session_id: isSet(object.session_id) ? String(object.session_id) : '',
+            persistent_session_id: isSet(object.persistent_session_id) ? String(object.persistent_session_id) : '',
+            govuk_signin_journey_id: isSet(object.govuk_signin_journey_id) ? String(object.govuk_signin_journey_id) : '',
             unknown_user_field: isSet(object.unknown_user_field) ? String(object.unknown_user_field) : '',
         };
     }
@@ -86,6 +83,9 @@ export class AuditEventUserMessage {
         message.email !== undefined && (obj.email = message.email);
         message.phone !== undefined && (obj.phone = message.phone);
         message.ip_address !== undefined && (obj.ip_address = message.ip_address);
+        message.session_id !== undefined && (obj.session_id = message.session_id);
+        message.persistent_session_id !== undefined && (obj.persistent_session_id = message.persistent_session_id);
+        message.govuk_signin_journey_id !== undefined && (obj.govuk_signin_journey_id = message.govuk_signin_journey_id);
         message.unknown_user_field !== undefined && (obj.unknown_user_field = message.unknown_user_field);
         return obj;
     }

--- a/event-processing/event-processor/tests/unit/app.test.ts
+++ b/event-processing/event-processor/tests/unit/app.test.ts
@@ -74,7 +74,7 @@ describe('Unit test for app handler', function () {
 
     it('accepts a bare minimum payload and stringifies', async () => {
         const expectedResult =
-            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","govuk_signin_journey_id":"","session_id":"","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","persistent_session_id":""}';
+            '{"event_id":"58339721-64c9-486b-903f-ad7e63fc45de","client_id":"","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234"}';
 
         const exampleMessage: IAuditEvent = {
             timestamp: 1609462861,
@@ -109,12 +109,10 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies an SQS event', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -125,6 +123,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -135,7 +136,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
@@ -163,12 +163,10 @@ describe('Unit test for app handler', function () {
 
     it('successfully stringifies multiple events', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -179,6 +177,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -189,7 +190,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
@@ -220,12 +220,10 @@ describe('Unit test for app handler', function () {
 
     it('successfully removes unrecognised elements from an audit event and user field and then logs to cloudwatch', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: UnknownAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -236,6 +234,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
                 unknown_user_field: 'some unknown user field'
             },
             platform: {
@@ -248,7 +249,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
             new_unknown_field: "an unknown field"
         };
 
@@ -278,12 +278,10 @@ describe('Unit test for app handler', function () {
 
     it('successfully populates missing formatted timestamp fields', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-01T01:01:01.000Z","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '',
@@ -294,6 +292,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -304,7 +305,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
@@ -332,12 +332,10 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on event name', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -348,6 +346,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -358,13 +359,10 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         const exampleInvalidMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -375,6 +373,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -385,7 +386,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });
@@ -421,12 +421,10 @@ describe('Unit test for app handler', function () {
 
     it('logs an error when validation fails on timestamp', async () => {
         const expectedResult =
-            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1","session_id":"c222c1ec","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"},"persistent_session_id":"some session id"}';
+            '{"event_id":"66258f3e-82fc-4f61-9ba0-62424e1f06b4","client_id":"some-client","timestamp":1609462861,"timestamp_formatted":"2021-01-23T15:43:21.842","event_name":"AUTHENTICATION_ATTEMPT","component_id":"1234","user":{"transaction_id":"a52f6f87","email":"foo@bar.com","phone":"07711223344","ip_address":"100.100.100.100","session_id":"c222c1ec","persistent_session_id":"some session id","govuk_signin_journey_id":"43143-233Ds-2823-283-dj299j1"},"platform":{"xray_trace_id":"24727sda4192"},"restricted":{"experian_ref":"DSJJSEE29392"},"extensions":{"response":"Authentication successful"}}';
 
         const exampleMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -437,6 +435,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -447,13 +448,10 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         const exampleInvalidMessage: IAuditEvent = {
             event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-            session_id: 'c222c1ec',
             client_id: 'some-client',
             timestamp: 0,
             timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -464,6 +462,9 @@ describe('Unit test for app handler', function () {
                 email: 'foo@bar.com',
                 phone: '07711223344',
                 ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
             },
             platform: {
                 xray_trace_id: '24727sda4192',
@@ -474,7 +475,6 @@ describe('Unit test for app handler', function () {
             extensions: {
                 response: 'Authentication successful',
             },
-            persistent_session_id: 'some session id',
         };
 
         (sns.publish().promise as MockedFunction<any>).mockResolvedValueOnce({Success: 'OK', MessageId: "1" });

--- a/event-processing/obfuscation/models/audit-event.ts
+++ b/event-processing/obfuscation/models/audit-event.ts
@@ -1,7 +1,5 @@
 export interface IAuditEvent {
     event_id?: string;
-    govuk_signin_journey_id?: string;
-    session_id?: string;
     client_id?: string;
     timestamp: number;
     timestamp_formatted?: string;
@@ -11,7 +9,6 @@ export interface IAuditEvent {
     platform?: unknown | undefined;
     restricted?: unknown | undefined;
     extensions?: unknown | undefined;
-    persistent_session_id?: string;
 }
 
 export interface IAuditEventUserMessage {
@@ -19,13 +16,14 @@ export interface IAuditEventUserMessage {
     email?: string;
     phone?: string;
     ip_address: string;
+    session_id?: string;
+    persistent_session_id?: string;
+    govuk_signin_journey_id?: string;
 }
 
 function createBaseAuditEvent(): IAuditEvent {
     return {
         event_id: '',
-        govuk_signin_journey_id: '',
-        session_id: '',
         client_id: '',
         timestamp: 0,
         timestamp_formatted: '',
@@ -35,7 +33,6 @@ function createBaseAuditEvent(): IAuditEvent {
         platform: undefined,
         restricted: undefined,
         extensions: undefined,
-        persistent_session_id: '',
     };
 }
 
@@ -47,12 +44,6 @@ export class AuditEvent {
             switch (value) {
                 case 'event_id':
                     event.event_id = jsonObject[value];
-                    break;
-                case 'govuk_signin_journey_id':
-                    event.govuk_signin_journey_id = jsonObject[value];
-                    break;
-                case 'session_id':
-                    event.session_id = jsonObject[value];
                     break;
                 case 'client_id':
                     event.client_id = jsonObject[value];
@@ -81,9 +72,6 @@ export class AuditEvent {
                 case 'extensions':
                     event.extensions = jsonObject[value];
                     break;
-                case 'persistent_session_id':
-                    event.persistent_session_id = jsonObject[value];
-                    break;
             }
         }
         return event;
@@ -91,7 +79,15 @@ export class AuditEvent {
 }
 
 function createBaseAuditEventUserMessage(): IAuditEventUserMessage {
-    return { transaction_id: '', email: '', phone: '', ip_address: '' };
+    return {
+        transaction_id: '',
+        email: '',
+        phone: '',
+        ip_address: '',
+        session_id: '',
+        persistent_session_id: '',
+        govuk_signin_journey_id: '',
+    };
 }
 
 export class AuditEventUserMessage {
@@ -110,6 +106,15 @@ export class AuditEventUserMessage {
                     break;
                 case 'ip_address':
                     user.ip_address = object.ip_address;
+                    break;
+                case 'session_id':
+                    user.session_id = object.session_id;
+                    break;
+                case 'persistent_session_id':
+                    user.persistent_session_id = object.persistent_session_id;
+                    break;
+                case 'govuk_signin_journey_id':
+                    user.govuk_signin_journey_id = object.govuk_signin_journey_id;
                     break;
             }
         }

--- a/event-processing/obfuscation/services/obfuscation-service.ts
+++ b/event-processing/obfuscation/services/obfuscation-service.ts
@@ -6,8 +6,7 @@ export class ObfuscationService {
         if (auditEvent.user) {
             const user = auditEvent.user as any;
             for (const k in user) {
-                if (k === 'ip_address') continue;
-                user[k] = this.obfuscate(user[k], hmacKey);
+                if (['transaction_id', 'email', 'phone'].indexOf(k) !== -1) user[k] = this.obfuscate(user[k], hmacKey);
             }
         }
 

--- a/event-processing/obfuscation/tests/unit/app.test.ts
+++ b/event-processing/obfuscation/tests/unit/app.test.ts
@@ -58,14 +58,11 @@ describe('Unit test for app handler', function () {
     it('accepts a bare minimum payload and stringifies', async () => {
         const exampleMessage: IAuditEvent = {
             event_id: "",
-            govuk_signin_journey_id: "",
-            session_id: "",
             client_id: "",
             timestamp: 1609462861,
             timestamp_formatted: "2021-01-23T15:43:21.842",
             event_name: "AUTHENTICATION_ATTEMPT",
-            component_id: "AUTH",
-            persistent_session_id: ""
+            component_id: "AUTH"
         }
 
         const data : string = Buffer.from(TestHelper.encodeAuditEvent(exampleMessage)).toString('base64')

--- a/event-processing/obfuscation/tests/unit/test-helper.ts
+++ b/event-processing/obfuscation/tests/unit/test-helper.ts
@@ -6,8 +6,6 @@ import { ObfuscationService } from '../../services/obfuscation-service';
 export class TestHelper {
     static exampleMessage: IAuditEvent = {
         event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-        govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-        session_id: 'c222c1ec',
         client_id: 'some-client',
         timestamp: 1609462861,
         timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -18,6 +16,9 @@ export class TestHelper {
             email: 'foo@bar.com',
             phone: '07711223344',
             ip_address: '100.100.100.100',
+            session_id: 'c222c1ec',
+            persistent_session_id: 'some session id',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
         },
         platform: {
             xray_trace_id: '24727sda4192',
@@ -29,13 +30,10 @@ export class TestHelper {
         extensions: {
             response: 'Authentication successful',
         },
-        persistent_session_id: 'some session id',
     };
 
     static exampleObfuscatedMessage: IAuditEvent = {
         event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-        govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-        session_id: 'c222c1ec',
         client_id: 'some-client',
         timestamp: 1609462861,
         timestamp_formatted: '2021-01-23T15:43:21.842',
@@ -46,6 +44,9 @@ export class TestHelper {
             email: ObfuscationService.obfuscate('foo@bar.com', 'secret-1-value'),
             phone: ObfuscationService.obfuscate('07711223344', 'secret-1-value'),
             ip_address: '100.100.100.100',
+            session_id: 'c222c1ec',
+            persistent_session_id: 'some session id',
+            govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
         },
         platform: {
             xray_trace_id: '24727sda4192',
@@ -57,7 +58,6 @@ export class TestHelper {
         extensions: {
             response: 'Authentication successful',
         },
-        persistent_session_id: 'some session id',
     };
 
     private static firehoseTransformationEvent: FirehoseTransformationEvent = {


### PR DESCRIPTION
Due to another change to the ADR we need to update the field placement of the following fields:

- session_id
- govuk_signin_journey_id
- persistant_session_id

The fields have now moved to the user sub-object.

Unit tests have been updated to reflect the changes.