### PR TITLE
Tma 313 fix bugs

### DIFF
--- a/tests/event-processing-tests/build.gradle
+++ b/tests/event-processing-tests/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.3.4'
     testImplementation 'org.junit.platform:junit-platform-suite:1.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 tasks {

--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -165,6 +165,9 @@ public class LambdaToS3StepDefinitions {
             // count will make sure it only searches for a finite time
             int count = 0;
 
+            // Reset correctS3 for next endpoint
+            correctS3 = null;
+
             // Has a retry loop in case it finds the wrong key on the first try
             // Count < 11 is enough time for it to be processed by the Firehose
             // If it is the first firehose being checked, it will wait the full time (or until it is found)

--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -128,7 +128,7 @@ public class LambdaToS3StepDefinitions {
      */
     @Then("there shouldn't be an error message in the lambda logs")
     public void there_shouldnt_be_an_error_message_in_the_lambda_cloudwatch() {
-        assertThat(log, not(containsString("ERROR")));
+        assertThat(log, not(containsString("[ERROR]")));
     }
 
     /**
@@ -136,7 +136,7 @@ public class LambdaToS3StepDefinitions {
      */
     @Then("there should be an error message in the lambda logs")
     public void there_should_be_an_error_message_in_the_lambda_cloudwatch() {
-        assertThat(log, containsString("ERROR"));
+        assertThat(log, containsString("[ERROR]"));
     }
 
     /**
@@ -144,8 +144,8 @@ public class LambdaToS3StepDefinitions {
      */
     @Then("there should be a warn message in the lambda logs")
     public void there_should_be_a_warn_message_in_the_lambda_cloudwatch() {
-        assertThat(log, not(containsString("ERROR")));
-        assertThat(log, containsString("WARN"));
+        assertThat(log, not(containsString("[ERROR]")));
+        assertThat(log, containsString("[WARN]"));
     }
 
     /**

--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -46,7 +46,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class LambdaToS3StepDefinitions {
     Region region = Region.EU_WEST_2;

--- a/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
+++ b/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
@@ -6,7 +6,7 @@ Feature: Raw event data journey from the lambda to S3
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
-    Then there shouldn't be an error message in the "<account>" lambda cloudwatch
+    Then there shouldn't be an error message in the lambda logs
     And the s3 below should have a new event matching the respective "<account>" output file
       | FRAUD    |
       | PERF     |
@@ -24,7 +24,7 @@ Feature: Raw event data journey from the lambda to S3
   Scenario Outline: Check messages don't pass through lambda if missing event_name
     Given the SQS file "LAMBDA_MISSING_EVENT_NAME.json" is available for the "<account>" team
     When the "<account>" lambda is invoked
-    Then there should be an error message in the "<account>" lambda cloudwatch
+    Then there should be an error message in the lambda logs
 
     Examples:
       | account     |
@@ -38,7 +38,7 @@ Feature: Raw event data journey from the lambda to S3
   Scenario Outline: Check messages don't pass through lambda if missing timestamp
     Given the SQS file "LAMBDA_MISSING_TIMESTAMP.json" is available for the "<account>" team
     When the "<account>" lambda is invoked
-    Then there should be an error message in the "<account>" lambda cloudwatch
+    Then there should be an error message in the lambda logs
 
     Examples:
       | account     |
@@ -54,7 +54,7 @@ Feature: Raw event data journey from the lambda to S3
     And the output file is available
       | FRAUD    |
     When the "<account>" lambda is invoked
-    Then there should be a warn message in the "<account>" lambda cloudwatch
+    Then there should be a warn message in the lambda logs
     And the s3 below should have a new event matching the respective "<account>" output file
       | FRAUD    |
     And this s3 event should not contain the "additional" field


### PR DESCRIPTION
This fixes two bugs:

1. Cloudwatch not finding all logs from the lambda
To do this, the lambda is called synchronously and we can then directly get the logs being sent to Cloudwatch without calling Cloudwatch directly. 

2. Searching the S3 buckets sometimes searches the wrong files
To do this, it now searches through the latest two files every 10 seconds for 100 seconds until the correct file is found. (If it is the second runthrough - i.e. it's already searched one S3 bucket for enough time - then it will not repeat the waiting and just check the bucket once).
