### PR TITLE
Tma 301 subscription scenarios 02

### DIFF
--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -54,6 +54,7 @@ public class LambdaToS3StepDefinitions {
     String timestamp;
     JSONObject correctS3;
     String log;
+    boolean firstSearch = true;
 
     /**
      * Checks that the input test data is present. And changes it to look like an SQS message
@@ -157,52 +158,27 @@ public class LambdaToS3StepDefinitions {
      */
     @And("the s3 below should have a new event matching the respective {string} output file {string}")
     public void the_s3_below_should_have_a_new_event_matching_the_respective_output_file(String account, String filename, DataTable endpoints) throws IOException, InterruptedException {
-
         // Loops through the possible endpoints
         List<List<String>> data = endpoints.asLists(String.class);
         for (List<String> endpoint : data) {
-            boolean foundInS3 = false;
-            // count will make sure it only searches for a finite time
-            int count = 0;
-
-            // Reset correctS3 for next endpoint
-            correctS3 = null;
-
-            // Has a retry loop in case it finds the wrong key on the first try
-            // Count < 11 is enough time for it to be processed by the Firehose
-            // If it is the first firehose being checked, it will wait the full time (or until it is found)
-            // If it is a later firehose, we know that enough time has already passed, so it only goes through the loop once
-            while (!foundInS3 && ((count < 11  && endpoint == data.get(0)) || (count < 1))) {
-                if (count > 0){
-                    Thread.sleep(10000);
-                }
-                count ++;
-
-                // Checks for latest key and saves the contents in the output variable
-                output = null;
-                findLatestKeys(endpoint.get(0).toLowerCase());
-
-                // Splits the batched outputs into individual jsons
-                List<JSONObject> array = separate(output);
-
-                // Takes the input file, and adds a timestamp to the component_id
-                Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + filename+".json").getAbsolutePath());
-                String file = Files.readString(filePath);
-                JSONObject json = new JSONObject(file);
-                JSONObject expectedS3 = addUniqueComponentID(json, account);
-
-                // Compares all individual jsons with our test data
-                for (JSONObject object : array) {
-                    if (compareOutput(object, expectedS3)) {
-                        foundInS3 = true;
-                        break;
-                    }
-                }
-            }
-
-            assertTrue(foundInS3);
+            assertTrue(findInS3(endpoint.get(0), filename, account));
         }
+    }
 
+    /**
+     * This searches the S3 bucket and checks that any new data does not contain the output file
+     *
+     * @param account       Which account inputted the message
+     * @param endpoints     The endpoints we're checking against
+     * @throws IOException
+     */
+    @And("the  S3 below should not have a new event matching the respective {string} output file {string}")
+    public void the_s3_below_should_not_have_a_new_event_matching_the_respective_output_file(String account,String filename, DataTable endpoints) throws IOException, InterruptedException {
+        // Loops through the possible outputs
+        List<List<String>> data = endpoints.asLists(String.class);
+        for (List<String> endpoint : data) {
+            assertFalse(findInS3(endpoint.get(0), filename, account));
+        }
     }
 
     /**
@@ -380,42 +356,58 @@ public class LambdaToS3StepDefinitions {
         return !isNull(correctS3);
     }
 
-    @And("the  S3 below should not have a new event matching the respective {string} output file {string}")
-    public void the_s3_below_should_not_have_a_new_event_matching_the_respective_output_file(String account,String filename, DataTable endpoints) throws IOException {
-        // Loops through the possible outputs
-        List<List<String>> data = endpoints.asLists(String.class);
-        for (List<String> endpoint : data) {
+    /**
+     * This searches the S3 bucket for the latest objects and compares them to the output file
+     *
+     * @param endpoint  Which S3 bucket we are searching
+     * @param filename  The output file name
+     * @param account   The account which sent the message
+     * @return          True or false depending on whether the message was found or not
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public boolean findInS3 (String endpoint, String filename, String account) throws IOException, InterruptedException {
+        boolean foundInS3 = false;
+        // count will make sure it only searches for a finite time
+        int count = 0;
+
+        // Reset correctS3 for next endpoint
+        correctS3 = null;
+
+        // Has a retry loop in case it finds the wrong key on the first try
+        // Count < 11 is enough time for it to be processed by the Firehose
+        // If it is the first firehose being checked, it will wait the full time (or until it is found)
+        // If it is a later firehose, we know that enough time has already passed, so it only goes through the loop once
+        while (!foundInS3 && ((count < 11  && firstSearch) || (count < 1))) {
+            if (count > 0){
+                Thread.sleep(10000);
+            }
+            count ++;
+
+            // Checks for latest key and saves the contents in the output variable
             output = null;
+            findLatestKeys(endpoint.toLowerCase());
 
-            // Checks for a new key
-            checkForNewKey(endpoint.get(0).toLowerCase());
+            // Splits the batched outputs into individual jsons
+            List<JSONObject> array = separate(output);
 
-            if (output !=null) {
+            // Takes the input file, and adds a timestamp to the component_id
+            Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint + filename+".json").getAbsolutePath());
+            String file = Files.readString(filePath);
+            JSONObject json = new JSONObject(file);
+            JSONObject expectedS3 = addUniqueComponentID(json, account);
 
-
-                // Takes the input file, and adds a timestamp to the component_id
-                Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + filename+".json").getAbsolutePath());
-                String file = Files.readString(filePath);
-                JSONObject json = new JSONObject(file);
-                JSONObject expectedS3 = addUniqueComponentID(json, account);
-
-                // Splits the batched outputs into individual jsons
-                List<JSONObject> array = separate(output);
-
-                // Compares all individual jsons with our test data
-                boolean foundInS3 = false;
-                for (JSONObject object : array) {
-                    if (compareOutput(object, expectedS3)) {
-                        foundInS3 = true;
-                        break;
-                    }
+            // Compares all individual jsons with our test data
+            for (JSONObject object : array) {
+                if (compareOutput(object, expectedS3)) {
+                    foundInS3 = true;
+                    break;
                 }
-
-                assertFalse(foundInS3);
             }
         }
-
+        firstSearch = false;
+        return foundInS3;
     }
 
-    }
+}
 

--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -78,12 +78,12 @@ public class LambdaToS3StepDefinitions {
      * @param endpoints     The endpoints we're checking against
      * @throws IOException
      */
-    @And("the output file is available")
-    public void the_output_file_is_available(DataTable endpoints) throws IOException{
+    @And("the output file {string} is available")
+    public void the_output_file_is_available(String filename,DataTable endpoints) throws IOException{
         // Loops through the possible endpoints
         List<List<String>> data = endpoints.asLists(String.class);
         for (List<String> endpoint : data) {
-            Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + "_S3_EXPECTED.json").getAbsolutePath());
+            Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + filename+".json").getAbsolutePath());
             Files.readString(filePath);
         }
     }
@@ -155,8 +155,8 @@ public class LambdaToS3StepDefinitions {
      * @param endpoints     The endpoints we're checking against
      * @throws IOException
      */
-    @And("the s3 below should have a new event matching the respective {string} output file")
-    public void the_s3_below_should_have_a_new_event_matching_the_respective_output_file(String account, DataTable endpoints) throws IOException, InterruptedException {
+    @And("the s3 below should have a new event matching the respective {string} output file {string}")
+    public void the_s3_below_should_have_a_new_event_matching_the_respective_output_file(String account, String filename, DataTable endpoints) throws IOException, InterruptedException {
 
         // Loops through the possible endpoints
         List<List<String>> data = endpoints.asLists(String.class);
@@ -186,7 +186,7 @@ public class LambdaToS3StepDefinitions {
                 List<JSONObject> array = separate(output);
 
                 // Takes the input file, and adds a timestamp to the component_id
-                Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + "_S3_EXPECTED.json").getAbsolutePath());
+                Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + filename+".json").getAbsolutePath());
                 String file = Files.readString(filePath);
                 JSONObject json = new JSONObject(file);
                 JSONObject expectedS3 = addUniqueComponentID(json, account);
@@ -379,4 +379,43 @@ public class LambdaToS3StepDefinitions {
         }
         return !isNull(correctS3);
     }
-}
+
+    @And("the  S3 below should not have a new event matching the respective {string} output file {string}")
+    public void the_s3_below_should_not_have_a_new_event_matching_the_respective_output_file(String account,String filename, DataTable endpoints) throws IOException {
+        // Loops through the possible outputs
+        List<List<String>> data = endpoints.asLists(String.class);
+        for (List<String> endpoint : data) {
+            output = null;
+
+            // Checks for a new key
+            checkForNewKey(endpoint.get(0).toLowerCase());
+
+            if (output !=null) {
+
+
+                // Takes the input file, and adds a timestamp to the component_id
+                Path filePath = Path.of(new File("src/test/resources/Test Data/" + endpoint.get(0) + filename+".json").getAbsolutePath());
+                String file = Files.readString(filePath);
+                JSONObject json = new JSONObject(file);
+                JSONObject expectedS3 = addUniqueComponentID(json, account);
+
+                // Splits the batched outputs into individual jsons
+                List<JSONObject> array = separate(output);
+
+                // Compares all individual jsons with our test data
+                boolean foundInS3 = false;
+                for (JSONObject object : array) {
+                    if (compareOutput(object, expectedS3)) {
+                        foundInS3 = true;
+                        break;
+                    }
+                }
+
+                assertFalse(foundInS3);
+            }
+        }
+
+    }
+
+    }
+

--- a/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR",
+  "component_id": ""
+}

--- a/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected_random.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected_random.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR_random",
+  "component_id": ""
+}

--- a/tests/event-processing-tests/src/test/resources/Test Data/PERF_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/PERF_expected.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR",
+  "component_id": ""
+}

--- a/tests/event-processing-tests/src/test/resources/Test Data/PERF_expected_random.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/PERF_expected_random.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR_random",
+  "component_id": ""
+}

--- a/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
@@ -1,0 +1,26 @@
+{
+  "event_id": "529f-dece-615e-dipv",
+  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+  "session_id": "8casd82c",
+  "client_id": "IPV",
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR",
+  "component_id": "",
+  "user": {
+    "transaction_id": "12e467e2",
+    "email": "m.thompson@randatmail.com",
+    "phone": "33600182839",
+    "ip_address": "181.246.129.108"
+  },
+  "platform": {
+    "xray_trace_id": "24727sda4192"
+  },
+  "restricted": {
+    "experian_ref": "DSJJSEE29392"
+  },
+  "extensions": {
+    "response": "Authentification successful"
+  },
+  "persistent_session_id": "..."
+}

--- a/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
@@ -1,0 +1,26 @@
+{
+  "event_id": "529f-dece-615e-dipv",
+  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+  "session_id": "8casd82c",
+  "client_id": "IPV",
+  "timestamp": 1647969131,
+  "timestamp_formatted": "2022-03-22T17:12:11.000Z",
+  "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR_random",
+  "component_id": "",
+  "user": {
+    "transaction_id": "12e467e2",
+    "email": "m.thompson@randatmail.com",
+    "phone": "33600182839",
+    "ip_address": "181.246.129.108"
+  },
+  "platform": {
+    "xray_trace_id": "24727sda4192"
+  },
+  "restricted": {
+    "experian_ref": "DSJJSEE29392"
+  },
+  "extensions": {
+    "response": "Authentification successful"
+  },
+  "persistent_session_id": "..."
+}

--- a/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
+++ b/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
@@ -2,12 +2,12 @@ Feature: Raw event data journey from the lambda to S3
 
   Scenario Outline: Check messages pass through lambda to S3
     Given the SQS file "LAMBDA_THROUGH_TO_S3.json" is available for the "<account>" team
-    And the output file is available
+    And the output file "_S3_EXPECTED" is available
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
     Then there shouldn't be an error message in the lambda logs
-    And the s3 below should have a new event matching the respective "<account>" output file
+    And the s3 below should have a new event matching the respective "<account>" output file "_S3_EXPECTED"
       | FRAUD    |
       | PERF     |
 
@@ -51,13 +51,55 @@ Feature: Raw event data journey from the lambda to S3
 
   Scenario Outline: Check messages receive a warning in Cloudwatch if addition fields are present
     Given the SQS file "LAMBDA_ADDITIONAL_FIELD.json" is available for the "<account>" team
-    And the output file is available
+    And the output file "_S3_EXPECTED" is available
       | FRAUD    |
     When the "<account>" lambda is invoked
     Then there should be a warn message in the lambda logs
-    And the s3 below should have a new event matching the respective "<account>" output file
+    And the s3 below should have a new event matching the respective "<account>" output file "_S3_EXPECTED"
       | FRAUD    |
     And this s3 event should not contain the "additional" field
+
+    Examples:
+      | account     |
+      | IPV         |
+      | IPVPass     |
+      | KBV         |
+      | KBVAddress  |
+      | KBVFraud    |
+      | SPOT        |
+
+
+  Scenario Outline: Checking the filter sends "AUTH_UPDATE_CLIENT_REQUEST_ERROR" only to Fraud
+    Given the SQS file "auth_update_client_request_error.json" is available for the "<account>" team
+    And the output file "_expected" is available
+      | FRAUD    |
+      | PERF     |
+    When the "<account>" lambda is invoked
+    Then there shouldn't be an error message in the lambda logs
+    And the s3 below should have a new event matching the respective "<account>" output file "_expected"
+      | FRAUD    |
+    And the  S3 below should not have a new event matching the respective "<account>" output file "_expected"
+      | PERF |
+
+    Examples:
+      | account     |
+      | IPV         |
+      | IPVPass     |
+      | KBV         |
+      | KBVAddress  |
+      | KBVFraud    |
+      | SPOT        |
+
+  Scenario Outline: Checking the filter sends "RANDOM_EVENT" to neither Fraud, nor Performance
+    Given the SQS file "random_event.json" is available for the "<account>" team
+    And the output file "_expected" is available
+      | FRAUD    |
+      | PERF     |
+    When the "<account>" lambda is invoked
+    Then there shouldn't be an error message in the lambda logs
+    And the  S3 below should not have a new event matching the respective "<account>" output file "_expected"
+      | FRAUD    |
+      | PERF     |
 
     Examples:
       | account     |

--- a/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
+++ b/tests/event-processing-tests/src/test/resources/features/LambdaToS3.feature
@@ -84,28 +84,19 @@ Feature: Raw event data journey from the lambda to S3
     Examples:
       | account     |
       | IPV         |
-      | IPVPass     |
-      | KBV         |
-      | KBVAddress  |
-      | KBVFraud    |
-      | SPOT        |
+
 
   Scenario Outline: Checking the filter sends "RANDOM_EVENT" to neither Fraud, nor Performance
     Given the SQS file "random_event.json" is available for the "<account>" team
-    And the output file "_expected" is available
+    And the output file "_expected_random" is available
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
     Then there shouldn't be an error message in the lambda logs
-    And the  S3 below should not have a new event matching the respective "<account>" output file "_expected"
+    And the  S3 below should not have a new event matching the respective "<account>" output file "_expected_random"
       | FRAUD    |
       | PERF     |
 
     Examples:
       | account     |
       | IPV         |
-      | IPVPass     |
-      | KBV         |
-      | KBVAddress  |
-      | KBVFraud    |
-      | SPOT        |


### PR DESCRIPTION
1. Added 2 additional scenarios for subscription. One for positive case where an event name common for FRAUD and PERF appear in the output an the second one is that we dont expect a random event name appear in any of FRAUD or PERF.
2. Removed excess examples because we are testing the SNS functionality rather than individual lambda functionality
3. updated the expected file name for scenario: "Checking the filter sends "RANDOM_EVENT" to neither Fraud, nor Performance"
4. Moving searching the S3 code to a function so that it can be called for both scenarios.