### PR TITLE
Update input files to match the schema

### DIFF
--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_ADDITIONAL_FIELD.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_ADDITIONAL_FIELD.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
@@ -11,7 +9,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -22,6 +23,5 @@
   "extensions": {
     "response": "Authentification successful"
   },
-  "persistent_session_id": "...",
   "additional": "Remove me"
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_EVENT_NAME.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_EVENT_NAME.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
@@ -10,7 +8,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -20,6 +21,5 @@
   },
   "extensions": {
     "response": "Authentification successful"
-  },
-  "persistent_session_id": "..."
+  }
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_TIMESTAMP.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_TIMESTAMP.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_JOURNEY_START",
@@ -10,7 +8,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -20,6 +21,5 @@
   },
   "extensions": {
     "response": "Authentification successful"
-  },
-  "persistent_session_id": "..."
+  }
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_THROUGH_TO_S3.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_THROUGH_TO_S3.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
@@ -11,7 +9,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -21,6 +22,5 @@
   },
   "extensions": {
     "response": "Authentification successful"
-  },
-  "persistent_session_id": "..."
+  }
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
@@ -11,7 +9,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -21,6 +22,5 @@
   },
   "extensions": {
     "response": "Authentification successful"
-  },
-  "persistent_session_id": "..."
+  }
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
@@ -1,7 +1,5 @@
 {
   "event_id": "529f-dece-615e-dipv",
-  "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
-  "session_id": "8casd82c",
   "client_id": "IPV",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
@@ -11,7 +9,10 @@
     "transaction_id": "12e467e2",
     "email": "m.thompson@randatmail.com",
     "phone": "33600182839",
-    "ip_address": "181.246.129.108"
+    "ip_address": "181.246.129.108",
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "session_id": "8casd82c",
+    "persistent_session_id": "..."
   },
   "platform": {
     "xray_trace_id": "24727sda4192"
@@ -21,6 +22,5 @@
   },
   "extensions": {
     "response": "Authentification successful"
-  },
-  "persistent_session_id": "..."
+  }
 }


### PR DESCRIPTION
govuk_signin_journey_id, session_id and persistent_session_id have been moved to the user field in accordance to https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0023-crossteam-audit-and-analysis-eventmessage-payload.md