### PR TITLE
Add user_id to input

### DIFF
--- a/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_S3_EXPECTED.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_S3_EXPECTED.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "session_id": "8casd82c",
     "persistent_session_id": "...",
-    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "session_id": "8casd82c",
     "persistent_session_id": "...",
-    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected_random.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/FRAUD_expected_random.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "session_id": "8casd82c",
     "persistent_session_id": "...",
-    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_ADDITIONAL_FIELD.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_ADDITIONAL_FIELD.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_EVENT_NAME.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_EVENT_NAME.json
@@ -11,7 +11,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_TIMESTAMP.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_MISSING_TIMESTAMP.json
@@ -11,7 +11,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_THROUGH_TO_S3.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/LAMBDA_THROUGH_TO_S3.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/auth_update_client_request_error.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"

--- a/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/random_event.json
@@ -12,7 +12,8 @@
     "ip_address": "181.246.129.108",
     "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd",
     "session_id": "8casd82c",
-    "persistent_session_id": "..."
+    "persistent_session_id": "...",
+    "user_id": "user_001"
   },
   "platform": {
     "xray_trace_id": "24727sda4192"


### PR DESCRIPTION
To keep the tests up to date with the latest schema, we need to include user_id in the test data