### PR TITLE
Fix incorrect tagging for audit

### DIFF
--- a/tests/audit-tests/build.gradle
+++ b/tests/audit-tests/build.gradle
@@ -29,7 +29,7 @@ tasks {
         useJUnitPlatform ()
         systemProperty("cucumber.execution.parallel.enabled", true)
         systemProperty("cucumber.junit-platform.naming-strategy", "long")
-        systemProperty("cucumber.filter.tags", System.getProperty("cucumber.filter.tags"))
+        systemProperty("cucumber.filter.tags", "@"+System.getenv("TEST_ENVIRONMENT"))
         systemProperty("cucumber.plugin", "pretty, json:"+System.getenv("TEST_REPORT_ABSOLUTE_DIR")+"/result.json, junit:"+System.getenv("TEST_REPORT_ABSOLUTE_DIR")+"/result.xml")
     }
 }


### PR DESCRIPTION
This will fix the tagging, and coincidentally, stop the tests running (which is intentional) until the features are tagged