### PR TITLE
Update tests to search cloudwatch as a backup search

### DIFF
--- a/tests/event-processing-tests/build.gradle
+++ b/tests/event-processing-tests/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.3.4'
     testImplementation 'org.junit.platform:junit-platform-suite:1.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 tasks {

--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -9,6 +9,13 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.GetLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
+import software.amazon.awssdk.services.cloudwatchlogs.model.OutputLogEvent;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -32,17 +39,12 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
 import java.util.zip.GZIPInputStream;
-import java.util.Objects;
 
-import static java.util.Objects.isNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,6 +56,7 @@ public class LambdaToS3StepDefinitions {
     Long timestamp;
     String log;
     boolean firstSearch = true;
+    String requestID;
 
     /**
      * Checks that the input test data is present. And changes it to look like an SQS message
@@ -115,6 +118,7 @@ public class LambdaToS3StepDefinitions {
             res = awsLambda.invoke(request);
             assertEquals(200, res.sdkHttpResponse().statusCode(), "A problem calling the lambda. HTTP response was incorrect.");
             log = new String (Base64.getDecoder().decode(res.logResult()), StandardCharsets.UTF_8);
+            requestID = res.responseMetadata().requestId();
 
 
         } catch (LambdaException e) {
@@ -124,28 +128,16 @@ public class LambdaToS3StepDefinitions {
     }
 
     /**
-     * Ensures that an error does not appear in cloudwatch log produced when the lambda was invoked
+     * Ensures that the provided string does appear in cloudwatch log produced when the lambda was invoked
      */
-    @Then("there shouldn't be an error message in the lambda logs")
-    public void there_shouldnt_be_an_error_message_in_the_lambda_cloudwatch() {
-        assertThat("A log from the lambda contained an [ERROR] message.", log, not(containsString("[ERROR]")));
-    }
+    @Then("there should be a {string} message in the {string} lambda logs")
+    public void there_should_be_a_message_in_the_lambda_cloudwatch(String message, String account) throws InterruptedException {
+        if (!log.contains(message)){
+            sendEmpty(account);
 
-    /**
-     * Ensures that an error does appear in cloudwatch log produced when the lambda was invoked
-     */
-    @Then("there should be an error message in the lambda logs")
-    public void there_should_be_an_error_message_in_the_lambda_cloudwatch() {
-        assertThat("No log from the lambda contained an [ERROR] message.", log, containsString("[ERROR]"));
-    }
-
-    /**
-     * Ensures that a warn error does appear in cloudwatch log produced when the lambda was invoked
-     */
-    @Then("there should be a warn message in the lambda logs")
-    public void there_should_be_a_warn_message_in_the_lambda_cloudwatch() {
-        assertThat("A log from the lambda contained an [ERROR] message.", log, not(containsString("[ERROR]")));
-        assertThat("No log from the lambda contained a [WARN] message.", log, containsString("[WARN]"));
+            String logGroup = "/aws/lambda/EventProcessorFunction-" + account;
+            assertTrue(searchCloudwatch(logGroup, requestID, message), "No log from the lambda contained a " + message + " message.");
+        }
     }
 
     /**
@@ -375,5 +367,98 @@ public class LambdaToS3StepDefinitions {
         return foundInS3;
     }
 
-}
+    /**
+     * This sends an empty payload through the correct lambda to force any cloudwatch logs to be processed if they haven't already
+     *
+     * @param account   The account which is sending the payload
+     */
+    public void sendEmpty(String account) {
 
+        JSONObject json = new JSONObject();
+        String empty = wrapJSON(json);
+
+        String functionName = "EventProcessorFunction-" + account;
+
+        // Opens the lambda client
+        try (LambdaClient awsLambda = LambdaClient.builder()
+                .region(region)
+                .build()) {
+            // Invoke the lambda with the input data
+            SdkBytes payload = SdkBytes.fromUtf8String(empty);
+            InvokeRequest.builder()
+                    .functionName(functionName)
+                    .payload(payload)
+                    .build();
+
+        } catch (LambdaException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * This waits for cloudwatch to update and searches the logs for the inputted string
+     * Note: it only searches the logs with the correct request id as found before
+     *
+     * @param logGroupName  The cloudwatch log to search
+     * @param toFind        The strings to be found
+     * @return              True or False depending on whether the string was found
+     * @throws InterruptedException
+     */
+    public boolean searchCloudwatch(String logGroupName, String... toFind) throws InterruptedException {
+        // Gives enough time for the cloudwatch logs to be processed
+        Thread.sleep(20000);
+        // This will track if the correct log has been found or not
+        boolean found;
+
+        // Opens the cloudwatch client
+        try (CloudWatchLogsClient cloudWatchLogsClient = CloudWatchLogsClient.builder()
+                .region(region)
+                .build()){
+
+            // Finds all log streams in Cloudwatch
+            DescribeLogStreamsRequest req = DescribeLogStreamsRequest.builder().logGroupName(logGroupName).orderBy("LastEventTime").descending(true).build();
+            DescribeLogStreamsResponse res2 = cloudWatchLogsClient.describeLogStreams(req);
+            List<LogStream> logStreams = res2.logStreams();
+
+            // Looks through all logs streams in the log group
+            for (LogStream logStream : logStreams) {
+                String logStreamName = logStream.logStreamName();
+                // Get the messages from the latest batch of cloudwatch messages
+                GetLogEventsRequest getLogEventsRequest = GetLogEventsRequest.builder()
+                        .logGroupName(logGroupName)
+                        .logStreamName(logStreamName)
+                        .startFromHead(false)
+                        .build();
+
+                // Loops through all logs in the stream
+                for (OutputLogEvent event : cloudWatchLogsClient.getLogEvents(getLogEventsRequest).events()) {
+                    // assumes found until it is not
+                    found = true;
+
+                    System.out.println(event.message() + Arrays.toString(toFind));
+
+                    // the log to be searched
+                    String message = event.message();
+                    // Loops through the inputs to be found
+                    for (String find : toFind){
+                        // If the messages does not contain the string, it has not been found
+                        if (!message.contains(find)) {
+                            found = false;
+                            break;
+                        }
+                    }
+                    // If all inputs were found, we return true
+                    if (found){
+                        return true;
+                    }
+                }
+            }
+        } catch (CloudWatchException e) {
+            System.err.println(e.awsErrorDetails().errorMessage());
+            System.exit(1);
+        }
+
+        return false;
+    }
+}

--- a/tests/event-processing-tests/src/test/resources/features/Build_LambdaToS3.feature
+++ b/tests/event-processing-tests/src/test/resources/features/Build_LambdaToS3.feature
@@ -7,7 +7,6 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
-    Then there shouldn't be an error message in the lambda logs
     And the s3 below should have a new event matching the respective "<account>" output file "_S3_EXPECTED"
       | FRAUD    |
       | PERF     |
@@ -25,7 +24,7 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
   Scenario Outline: Check messages don't pass through lambda if missing event_name
     Given the SQS file "LAMBDA_MISSING_EVENT_NAME.json" is available for the "<account>" team
     When the "<account>" lambda is invoked
-    Then there should be an error message in the lambda logs
+    Then there should be a "[ERROR]" message in the "<account>" lambda logs
 
     Examples:
       | account     |
@@ -39,7 +38,7 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
   Scenario Outline: Check messages don't pass through lambda if missing timestamp
     Given the SQS file "LAMBDA_MISSING_TIMESTAMP.json" is available for the "<account>" team
     When the "<account>" lambda is invoked
-    Then there should be an error message in the lambda logs
+    Then there should be a "[ERROR]" message in the "<account>" lambda logs
 
     Examples:
       | account     |
@@ -55,7 +54,7 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
     And the output file "_S3_EXPECTED" is available
       | FRAUD    |
     When the "<account>" lambda is invoked
-    Then there should be a warn message in the lambda logs
+    Then there should be a "[WARN]" message in the "<account>" lambda logs
     And the s3 below should have a new event matching the respective "<account>" output file "_S3_EXPECTED"
       | FRAUD    |
 
@@ -75,7 +74,6 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
-    Then there shouldn't be an error message in the lambda logs
     And the s3 below should have a new event matching the respective "<account>" output file "_expected"
       | FRAUD    |
     And the  S3 below should not have a new event matching the respective "<account>" output file "_expected"
@@ -92,7 +90,6 @@ Feature: Raw event data journey from the lambda to S3 for build (and dev) enviro
       | FRAUD    |
       | PERF     |
     When the "<account>" lambda is invoked
-    Then there shouldn't be an error message in the lambda logs
     And the  S3 below should not have a new event matching the respective "<account>" output file "_expected_random"
       | FRAUD    |
       | PERF     |


### PR DESCRIPTION
In the step definitions:
- removed unused imports
- use requestID to track the specific lambda invoke
- remove checking no error message step
- combine checking for ERROR and WARN
- Add function to send empty message (this will force the logs to be send if the error discovered before occurs)
- Add function to search cloudwatch logs

build.gradle:
-remove unused dependency

feature:
- remove cloudwatch search for no error
- reword search for ERROR and WARN so they can use the same step definition