### PR TITLE
Tma 483 add additional field in cleanser

### DIFF
--- a/event-processing/lambda/models/cleansed-event.ts
+++ b/event-processing/lambda/models/cleansed-event.ts
@@ -1,9 +1,18 @@
+export interface ICleansedEvidenceEvent {
+    validityScore?: number;
+}
+
+export interface ICleansedExtensionsEvent {
+    evidence?: unknown | undefined;
+}
+
 export interface ICleansedEvent {
     event_id: string;
     event_name: string;
     component_id: string;
     timestamp: number;
     timestamp_formatted: string;
+    extensions?: unknown | undefined;
 }
 
 export class CleansedEvent implements ICleansedEvent {
@@ -12,6 +21,7 @@ export class CleansedEvent implements ICleansedEvent {
     readonly component_id: string;
     readonly timestamp: number;
     readonly timestamp_formatted: string;
+    readonly extensions?: unknown | undefined;
 
     constructor(
         event_id: string,
@@ -19,11 +29,15 @@ export class CleansedEvent implements ICleansedEvent {
         component_id: string,
         timestamp: number,
         timestamp_formatted: string,
+        extensions?: unknown | undefined,
     ) {
         this.event_id = event_id;
         this.event_name = event_name;
         this.component_id = component_id;
         this.timestamp = timestamp;
         this.timestamp_formatted = timestamp_formatted;
+        if (extensions != undefined && (extensions as ICleansedExtensionsEvent).evidence) {
+          this.extensions = { evidence : { validityScore : ((extensions as ICleansedExtensionsEvent).evidence as ICleansedEvidenceEvent).validityScore } };
+        }
     }
 }

--- a/event-processing/lambda/services/cleansing-service.ts
+++ b/event-processing/lambda/services/cleansing-service.ts
@@ -9,6 +9,7 @@ export class CleansingService {
             auditEvent.component_id,
             auditEvent.timestamp,
             auditEvent.timestamp_formatted,
+            auditEvent.extensions,
         );
     }
 }

--- a/event-processing/lambda/tests/test-helpers/cleanser-helper.ts
+++ b/event-processing/lambda/tests/test-helpers/cleanser-helper.ts
@@ -31,6 +31,9 @@ export class CleanserHelper {
             },
             extensions: {
                 response: 'Authentication successful',
+                evidence: {
+                  validityScore: 2,
+                }
             },
         };
     }
@@ -42,6 +45,11 @@ export class CleanserHelper {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            extensions: {
+                evidence: {
+                  validityScore: 2,
+                }
+            },
         };
     }
 }

--- a/event-processing/lambda/tests/unit/app.cleanser.test.ts
+++ b/event-processing/lambda/tests/unit/app.cleanser.test.ts
@@ -20,7 +20,7 @@ jest.mock("aws-sdk", () => {
 
 describe('Unit test for app handler', function () {
     let consoleWarningMock: jest.SpyInstance;
-    
+
     beforeEach(() => {
         consoleWarningMock = jest.spyOn(global.console, 'log');
     });
@@ -55,9 +55,9 @@ describe('Unit test for app handler', function () {
                 result: "Ok"
             }]
         }
-        
+
         const firehoseEvent = TestHelper.createFirehoseEventWithEncodedMessage(TestHelper.encodeAuditEvent(exampleMessage));
-        
+
         const result = await handler(firehoseEvent);
         expect(result).toEqual(expectedResult);
     });
@@ -108,7 +108,7 @@ describe('Unit test for app handler', function () {
         expect(result).toEqual(expectedResult);
     });
 
-    it('cleanses all messages when receiving an array', async () => {
+    it('cleanses all messages when receiving an array including evidence to be kept in the extensions field', async () => {
 
         const expectedData : string = Buffer.from(TestHelper.encodeAuditEventArray(CleanserHelper.exampleCleansedMessage())).toString('base64')
         const expectedResult : FirehoseTransformationResult = {


### PR DESCRIPTION
To comply with a performance request, extensions.evidence.validityScore should be added to the performance index - i.e. not be removed by the cleanser function.