### PR TITLE
TMA-484 Correct check for empty string

### DIFF
--- a/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
+++ b/tests/event-processing-tests/src/test/java/uk/gov/di/txma/eventprocessor/bdd/LambdaToS3StepDefinitions.java
@@ -228,7 +228,7 @@ public class LambdaToS3StepDefinitions {
     private JSONObject addComponentIdAndTimestampFields(JSONObject messageAsJSON, String account){
 
         // Only adds the new component_id if it's already in the file and empty
-        if (messageAsJSON.has("component_id") && messageAsJSON.get("component_id") == ""){
+        if (messageAsJSON.has("component_id") && messageAsJSON.get("component_id").toString().isEmpty()){
             messageAsJSON.put("component_id", account);
         }
         // Only adds the new timestamp if it's already in the file


### PR DESCRIPTION
When using `==""` it was not correctly checking if the string was empty and was not behaving as expected.