### PR TITLE
TMA-487 Leave one object in each bucket

### DIFF
--- a/tests/event-processing-tests/src/main/java/uk/gov/di/txma/eventprocessor/Cleanup.java
+++ b/tests/event-processing-tests/src/main/java/uk/gov/di/txma/eventprocessor/Cleanup.java
@@ -29,7 +29,7 @@ public class Cleanup {
 
             while (true) {
                 ListObjectsV2Response res = s3.listObjectsV2(listObjects);
-                for (S3Object object : res.contents()){
+                for (S3Object object : res.contents().subList(1, res.contents().size())){
                     DeleteObjectRequest request = DeleteObjectRequest.builder()
                             .bucket(bucketName)
                             .key(object.key())


### PR DESCRIPTION
By leaving one object in each bucket, the SDK should be able to not error in the same way and wait rather than stopping the test.