### PR TITLE
Allow Cross Account Bucket Access

### DIFF
--- a/audit/audit-template.yml
+++ b/audit/audit-template.yml
@@ -171,7 +171,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: true
+        RestrictPublicBuckets: false
       VersioningConfiguration:
         Status: "Enabled"
       LoggingConfiguration:

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1553,7 +1553,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: true
+        RestrictPublicBuckets: false
       LoggingConfiguration:
         DestinationBucketName: !Ref SplunkDeliveryBucketLogsBucket
         LogFilePrefix: "event-processing/fraud-splunk-delivery-failure-bucket/"
@@ -1641,7 +1641,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: true
+        RestrictPublicBuckets: false
       LoggingConfiguration:
         DestinationBucketName: !Ref SplunkDeliveryBucketLogsBucket
         LogFilePrefix: "event-processing/performance-splunk-delivery-failure-bucket/"


### PR DESCRIPTION
Allow the source buckets for CSLS log shipping to allow for cross account policies.

'RestrictPublicBuckets' only allows for principals within the same account.