### PR TITLE
Revert "Allow the source buckets for CSLS log shipping to allow for c…

### DIFF
--- a/audit/audit-template.yml
+++ b/audit/audit-template.yml
@@ -171,7 +171,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: false
+        RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: "Enabled"
       LoggingConfiguration:

--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1553,7 +1553,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: false
+        RestrictPublicBuckets: true
       LoggingConfiguration:
         DestinationBucketName: !Ref SplunkDeliveryBucketLogsBucket
         LogFilePrefix: "event-processing/fraud-splunk-delivery-failure-bucket/"
@@ -1641,7 +1641,7 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
-        RestrictPublicBuckets: false
+        RestrictPublicBuckets: true
       LoggingConfiguration:
         DestinationBucketName: !Ref SplunkDeliveryBucketLogsBucket
         LogFilePrefix: "event-processing/performance-splunk-delivery-failure-bucket/"


### PR DESCRIPTION
…ross account policies."

This reverts commit 6bfd27c45bb3655428d6b48b9fcea9c0af9f02d7.

The pipelines don't accommodate this change currently due to restrictions on the checkov hook implementation and the inability to exclude CKV_AWS_56.

We have raised this with DevPlatform and are hopeful working with them and CSLS we can figure out the issue with the log shipping for S3.