### PR TITLE
TMA-549 Update the character encoding from 'ascii' to 'utf-8'. We wer…

### DIFF
--- a/event-processing/lambda/cleanser-app.ts
+++ b/event-processing/lambda/cleanser-app.ts
@@ -14,7 +14,7 @@ export const handler = async (event: FirehoseTransformationEvent): Promise<Fireh
     const transformationResult: FirehoseRecordTransformationStatus = 'Ok';
 
     const output = event.records.map((record: FirehoseTransformationEventRecord) => {
-        const plaintextData: string = Buffer.from(record.data, 'base64').toString('ascii');
+        const plaintextData: string = Buffer.from(record.data, 'base64').toString('utf-8');
         const events: unknown[] = JSON.parse(plaintextData);
         const cleansedEvents: ICleansedEvent[] = [];
         let data: string;

--- a/event-processing/lambda/obfuscation-app.ts
+++ b/event-processing/lambda/obfuscation-app.ts
@@ -23,7 +23,7 @@ export const handler = async (event: FirehoseTransformationEvent): Promise<Fireh
     }
 
     const output = event.records.map((record: FirehoseTransformationEventRecord) => {
-        const plaintextData: string = Buffer.from(record.data, 'base64').toString('ascii');
+        const plaintextData: string = Buffer.from(record.data, 'base64').toString('utf-8');
         const events: unknown[] = JSON.parse(plaintextData);
         const obfuscatedEvents: unknown[] = [];
         let data: string;

--- a/event-processing/lambda/services/key-service.ts
+++ b/event-processing/lambda/services/key-service.ts
@@ -23,7 +23,7 @@ export class KeyService {
         }
 
         if (data.SecretBinary) {
-            secret = Buffer.from(data.SecretBinary.toString(), 'base64').toString('ascii');
+            secret = Buffer.from(data.SecretBinary.toString(), 'base64').toString('utf-8');
         } else if (data.SecretString) {
             secret = data.SecretString;
         } else {

--- a/event-processing/lambda/tests/unit/app.obfuscation.test.ts
+++ b/event-processing/lambda/tests/unit/app.obfuscation.test.ts
@@ -273,7 +273,7 @@ describe('Unit test for app handler', function () {
 
         expect(result).toEqual(expectedResult);
 
-        const resultData = Buffer.from(result.records[0].data, 'base64').toString('ascii');
+        const resultData = Buffer.from(result.records[0].data, 'base64').toString('utf-8');
         const resultAuditEvent: IAuditEvent = AuditEvent.fromJSONString(resultData);
 
         expect(resultAuditEvent).toEqual(expectedData);
@@ -308,7 +308,7 @@ describe('Unit test for app handler', function () {
         const result = await handler(firehoseEvent);
 
         expect(result).toEqual(expectedResult);
-        const resultData = Buffer.from(result.records[0].data, 'base64').toString('ascii');
+        const resultData = Buffer.from(result.records[0].data, 'base64').toString('utf-8');
         const resultAuditEvent: unknown = JSON.parse(resultData);
         expect(resultAuditEvent).toEqual(expectedData);
     });
@@ -332,7 +332,7 @@ describe('Unit test for app handler', function () {
         const result = await handler(firehoseEvent);
 
         expect(result).toEqual(expectedResult);
-        const resultData = Buffer.from(result.records[0].data, 'base64').toString('ascii');
+        const resultData = Buffer.from(result.records[0].data, 'base64').toString('utf-8');
         const resultAuditEvent: unknown = JSON.parse(resultData);
         expect(resultAuditEvent).toEqual(expectedData);
     });
@@ -358,7 +358,7 @@ describe('Unit test for app handler', function () {
         const result = await handler(firehoseEvent);
 
         expect(result).toEqual(expectedResult);
-        const resultData = Buffer.from(result.records[0].data, 'base64').toString('ascii');
+        const resultData = Buffer.from(result.records[0].data, 'base64').toString('utf-8');
         const resultAuditEvent: unknown = JSON.parse(resultData);
         expect(resultAuditEvent).toEqual(expectedData);
     });


### PR DESCRIPTION
…e receiving characters that when encoded as 'ascii' where not able to be parsed by 'JSON.parse' which caused the errors seen.

Example character: Î