### PR TITLE
We can't map the notification configuration to the CSLS queues until …

### DIFF
--- a/analysis/analysis-template.yml
+++ b/analysis/analysis-template.yml
@@ -139,36 +139,36 @@ Resources:
         Rules:
           - ExpirationInDays: 7
             Status: Enabled
-      NotificationConfiguration:
-        QueueConfigurations:
-          !If
-          - IsProductionOrStaging
-          - - Event: "s3:ObjectCreated:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-            - Event: "s3:ObjectRestore:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-          - - !Ref AWS::NoValue
+#      NotificationConfiguration:
+#        QueueConfigurations:
+#          !If
+#          - IsProductionOrStaging
+#          - - Event: "s3:ObjectCreated:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#            - Event: "s3:ObjectRestore:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#          - - !Ref AWS::NoValue
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
 
-  AthenaQueryResultsBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Condition: IsProductionOrStaging
-    Properties:
-      Bucket: !Ref AthenaQueryResultsBucket
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: 'Allow'
-            Resource:
-              - !GetAtt AthenaQueryResultsBucket.Arn
-              - !Sub '${AthenaQueryResultsBucket.Arn}/*'
-            Principal:
-              AWS: "{{resolve:ssm:CSLSS3LambdaARN}}"
-            Action:
-              - 's3:Get*'
-              - 's3:List*'
+#  AthenaQueryResultsBucketPolicy:
+#    Type: AWS::S3::BucketPolicy
+#    Condition: IsProductionOrStaging
+#    Properties:
+#      Bucket: !Ref AthenaQueryResultsBucket
+#      PolicyDocument:
+#        Version: "2012-10-17"
+#        Statement:
+#          - Effect: 'Allow'
+#            Resource:
+#              - !GetAtt AthenaQueryResultsBucket.Arn
+#              - !Sub '${AthenaQueryResultsBucket.Arn}/*'
+#            Principal:
+#              AWS: "{{resolve:ssm:CSLSS3LambdaARN}}"
+#            Action:
+#              - 's3:Get*'
+#              - 's3:List*'
 
   AthenaQueryResultsBucketAccessLogsBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
…permissions are changed in the CSLS account. Comment this out until this is done so we can unblock our release.