### PR TITLE
Turn off CSLS notifications to temporarily try to fix pipeline breaking

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1703,15 +1703,15 @@ Resources:
           - Id: DeleteRedundantFiles
             Status: Enabled
             ExpirationInDays: 7
-      NotificationConfiguration:
-        QueueConfigurations:
-          !If
-          - IsProductionOrStaging
-          - - Event: "s3:ObjectCreated:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-            - Event: "s3:ObjectRestore:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-          - - !Ref AWS::NoValue
+#      NotificationConfiguration:
+#        QueueConfigurations:
+#          !If
+#          - IsProductionOrStaging
+#          - - Event: "s3:ObjectCreated:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#            - Event: "s3:ObjectRestore:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#          - - !Ref AWS::NoValue
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
@@ -1796,15 +1796,15 @@ Resources:
           - Id: DeleteRedundantFiles
             Status: Enabled
             ExpirationInDays: 7
-      NotificationConfiguration:
-        QueueConfigurations:
-          !If
-          - IsProductionOrStaging
-          - - Event: "s3:ObjectCreated:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-            - Event: "s3:ObjectRestore:*"
-              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-          - - !Ref AWS::NoValue
+#      NotificationConfiguration:
+#        QueueConfigurations:
+#          !If
+#          - IsProductionOrStaging
+#          - - Event: "s3:ObjectCreated:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#            - Event: "s3:ObjectRestore:*"
+#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+#          - - !Ref AWS::NoValue
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred


### PR DESCRIPTION
We have started getting an error of Configuration overlap when trying to deploy some S3 buckets in staging. Looking it up, it seems to be due to having notifications of the same event type. The only notifications for these buckets are for the CSLS logs (not that we have managed to get the logs through yet).

This will turn off those notifications to try and assess the issue