### PR TITLE
TMA-640 Add log subscription to CSLS to allow them to monitor our failed events

### DIFF
--- a/event-processing/event-processing-template.yml
+++ b/event-processing/event-processing-template.yml
@@ -1704,14 +1704,12 @@ Resources:
             Status: Enabled
             ExpirationInDays: 7
       NotificationConfiguration:
-#        QueueConfigurations:
-#          !If
-#          - IsProductionOrStaging
-#          - - Event: "s3:ObjectCreated:*"
-#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-#            - Event: "s3:ObjectRestore:*"
-#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-#          - - !Ref AWS::NoValue
+        QueueConfigurations:
+          !If
+          - IsProductionOrStaging
+          - - Event: "s3:ObjectRestore:*"
+              Queue: arn:aws:sqs:eu-west-2:248098332657:temporaryCSLSqueue
+          - - !Ref AWS::NoValue
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
@@ -1821,15 +1819,13 @@ Resources:
           - Id: DeleteRedundantFiles
             Status: Enabled
             ExpirationInDays: 7
-#      NotificationConfiguration:
-#        QueueConfigurations:
-#          !If
-#          - IsProductionOrStaging
-#          - - Event: "s3:ObjectCreated:*"
-#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-#            - Event: "s3:ObjectRestore:*"
-#              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
-#          - - !Ref AWS::NoValue
+      NotificationConfiguration:
+        QueueConfigurations:
+          !If
+          - IsProductionOrStaging
+          - - Event: "s3:ObjectRestore:*"
+              Queue: "{{resolve:ssm:CSLSS3QueueARN}}"
+          - - !Ref AWS::NoValue
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
@@ -2936,5 +2932,14 @@ Resources:
     Properties:
       LogGroupName:
         Ref: "CleanserLogGroup"
+      FilterPattern: ""
+      DestinationArn: "{{resolve:ssm:CSLSLogsDestination}}"
+
+  ReIngestFunctionLogsSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsProductionOrStaging
+    Properties:
+      LogGroupName:
+        Ref: "ReIngestLogGroup"
       FilterPattern: ""
       DestinationArn: "{{resolve:ssm:CSLSLogsDestination}}"


### PR DESCRIPTION
This uses the reingest lambda to monitor the failures for CSLS rather than the S3 bucket - this is to prevent the notification events being duplicated.