### PR TITLE
Tma 643 add client id and journey id to performance

### DIFF
--- a/event-processing/lambda/models/cleansed-event.ts
+++ b/event-processing/lambda/models/cleansed-event.ts
@@ -8,12 +8,18 @@ export interface ICleansedExtensionsEvent {
     evidence?: ICleansedEvidenceEvent | undefined;
 }
 
+export interface ICleansedUserEvent {
+    govuk_signin_journey_id?: string;
+}
+
 export interface ICleansedEvent {
     event_id: string;
     event_name: string;
     component_id: string;
     timestamp: number;
     timestamp_formatted: string;
+    client_id?: string;
+    user?: unknown | undefined;
     extensions?: unknown | undefined;
     reIngestCount?: number;
 }
@@ -24,6 +30,8 @@ export class CleansedEvent implements ICleansedEvent {
     readonly component_id: string;
     readonly timestamp: number;
     readonly timestamp_formatted: string;
+    readonly client_id?: string;
+    readonly user?: unknown | undefined;
     readonly extensions?: unknown | undefined;
     readonly reIngestCount?: number;
 
@@ -33,6 +41,8 @@ export class CleansedEvent implements ICleansedEvent {
         component_id: string,
         timestamp: number,
         timestamp_formatted: string,
+        client_id?: string,
+        user?: unknown | undefined,
         extensions?: unknown | undefined,
         reIngestCount?: number,
     ) {
@@ -41,7 +51,14 @@ export class CleansedEvent implements ICleansedEvent {
         this.component_id = component_id;
         this.timestamp = timestamp;
         this.timestamp_formatted = timestamp_formatted;
+        this.client_id = client_id;
         this.reIngestCount = reIngestCount;
+
+        if (user != undefined && (user as ICleansedUserEvent).govuk_signin_journey_id) {
+            this.user = {
+                govuk_signin_journey_id: (user as ICleansedUserEvent).govuk_signin_journey_id,
+            } as ICleansedUserEvent;
+        }
 
         if (extensions != undefined && (extensions as ICleansedExtensionsEvent).evidence != undefined) {
             const evidence = CleansedEvent.CleanseEvidenceArrayEvent(

--- a/event-processing/lambda/services/cleansing-service.ts
+++ b/event-processing/lambda/services/cleansing-service.ts
@@ -9,6 +9,8 @@ export class CleansingService {
             auditEvent.component_id,
             auditEvent.timestamp,
             auditEvent.timestamp_formatted,
+            auditEvent.client_id,
+            auditEvent.user,
             auditEvent.extensions,
             auditEvent.reIngestCount,
         );

--- a/event-processing/lambda/tests/test-helpers/cleanser-helper.ts
+++ b/event-processing/lambda/tests/test-helpers/cleanser-helper.ts
@@ -91,7 +91,11 @@ export class CleanserHelper {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'some-client',
             reIngestCount: 0,
+            user: {
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
+            },
             extensions: {
                 evidence: [
                     {
@@ -151,7 +155,11 @@ export class CleanserHelper {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'some-client',
             reIngestCount: 0,
+            user: {
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
+            },
             extensions: {
                 evidence: [
                     {

--- a/event-processing/lambda/tests/test-helpers/obfuscation-helper.ts
+++ b/event-processing/lambda/tests/test-helpers/obfuscation-helper.ts
@@ -36,34 +36,34 @@ export class ObfuscationHelper {
     }
 
     static exampleReIngestAuditMessage(): IAuditEvent {
-       return {
-           event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
-           client_id: 'some-client',
-           timestamp: 1609462861,
-           timestamp_formatted: '2021-01-23T15:43:21.842',
-           event_name: 'AUTHENTICATION_ATTEMPT',
-           component_id: 'AUTH',
-           user: {
-               transaction_id: ObfuscationService.obfuscateField('a52f6f87', 'secret-1-value'),
-               user_id: 'some_user_id',
-               email: ObfuscationService.obfuscateField('foo@bar.com', 'secret-1-value'),
-               phone: ObfuscationService.obfuscateField('07711223344', 'secret-1-value'),
-               ip_address: '100.100.100.100',
-               session_id: 'c222c1ec',
-               persistent_session_id: 'some session id',
-               govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
-               device_id: ObfuscationService.obfuscateField('some known device', 'secret-1-value'),
-           },
-           platform: {
-               xray_trace_id: '24727sda4192',
-           },
-           restricted: {
-               experian_ref: ObfuscationService.obfuscateField('DSJJSEE29392', 'secret-1-value'),
-           },
-           extensions: {
-               response: 'Authentication successful',
-           },
-           reIngestCount: 1,
-       };
-   }
+        return {
+            event_id: '66258f3e-82fc-4f61-9ba0-62424e1f06b4',
+            client_id: 'some-client',
+            timestamp: 1609462861,
+            timestamp_formatted: '2021-01-23T15:43:21.842',
+            event_name: 'AUTHENTICATION_ATTEMPT',
+            component_id: 'AUTH',
+            user: {
+                transaction_id: ObfuscationService.obfuscateField('a52f6f87', 'secret-1-value'),
+                user_id: 'some_user_id',
+                email: ObfuscationService.obfuscateField('foo@bar.com', 'secret-1-value'),
+                phone: ObfuscationService.obfuscateField('07711223344', 'secret-1-value'),
+                ip_address: '100.100.100.100',
+                session_id: 'c222c1ec',
+                persistent_session_id: 'some session id',
+                govuk_signin_journey_id: '43143-233Ds-2823-283-dj299j1',
+                device_id: ObfuscationService.obfuscateField('some known device', 'secret-1-value'),
+            },
+            platform: {
+                xray_trace_id: '24727sda4192',
+            },
+            restricted: {
+                experian_ref: ObfuscationService.obfuscateField('DSJJSEE29392', 'secret-1-value'),
+            },
+            extensions: {
+                response: 'Authentication successful',
+            },
+            reIngestCount: 1,
+        };
+    }
 }

--- a/event-processing/lambda/tests/unit/app.cleanser.test.ts
+++ b/event-processing/lambda/tests/unit/app.cleanser.test.ts
@@ -34,6 +34,7 @@ describe('Unit test for app handler', function () {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'My-client-id',
             reIngestCount: 0,
         };
 
@@ -66,12 +67,12 @@ describe('Unit test for app handler', function () {
             session_id: 'aaaa-bbbb-cccc-dddd-1234',
             persistent_session_id: 'aaaa-bbbb-cccc-dddd-1234',
             govuk_signin_journey_id: 'aaaa-bbbb-cccc-dddd-1234',
-            device_id:'some known device'
+            device_id: 'some known device',
         };
 
         const exampleMessage: IEnrichedAuditEvent = {
             event_id: '123456789',
-            client_id: 'My-Client-Id',
+            client_id: 'My-client-id',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
             event_name: 'AUTHENTICATION_ATTEMPT',
@@ -86,7 +87,11 @@ describe('Unit test for app handler', function () {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'My-client-id',
             reIngestCount: 0,
+            user: {
+                govuk_signin_journey_id: 'aaaa-bbbb-cccc-dddd-1234',
+            },
         };
 
         const data: string = Buffer.from(TestHelper.encodeAuditEvent(outputMessage)).toString('base64');
@@ -201,6 +206,7 @@ describe('Unit test for app handler', function () {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'My-client-id',
             reIngestCount: 0,
         };
 
@@ -243,6 +249,7 @@ describe('Unit test for app handler', function () {
             component_id: 'AUTH',
             timestamp: 1609462861,
             timestamp_formatted: '2021-01-23T15:43:21.842',
+            client_id: 'My-client-id',
             reIngestCount: 0,
         };
 

--- a/event-processing/lambda/tests/unit/services/cleansing-service.test.ts
+++ b/event-processing/lambda/tests/unit/services/cleansing-service.test.ts
@@ -12,6 +12,9 @@ describe('Unit test for cleansing-service', function () {
             event_id: '123456789',
             component_id: '1234',
             client_id: 'An Example Client',
+            user: {
+                transaction_id: 'a52f6f87',
+            },
             reIngestCount: 0,
         };
 
@@ -21,6 +24,7 @@ describe('Unit test for cleansing-service', function () {
             event_name: 'AUTHENTICATION_ATTEMPT',
             event_id: '123456789',
             component_id: '1234',
+            client_id: 'An Example Client',
             reIngestCount: 0,
         };
 

--- a/tests/event-processing-tests/src/test/resources/Test Data/App/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/App/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "DCMAW_CRI_START",
   "component_id": "https://www.review-b.staging.account.gov.uk",
+  "client_id": "authOrchestratorDocApp",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/AuthAccountMgmt/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/AuthAccountMgmt/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "AUTH_LOG_IN_SUCCESS",
   "component_id": "https://auth.staging.account.gov.uk",
+  "client_id": "e4421ac7-bb47-4467-bdeb-18e81881990c",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/AuthOIDC/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/AuthOIDC/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "AUTH_LOG_OUT_SUCCESS",
   "component_id": "https://oidc.staging.account.gov.uk",
+  "client_id": "f4b55862-1d5e-4508-a7a8-ee8e3ac2f3c2",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/IPV/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/IPV/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_JOURNEY_START",
   "component_id": "https://identity.staging.account.gov.uk",
+  "client_id": "NO_IPV_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/IPVCI/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/IPVCI/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_CONTRA_INDICATOR_STORAGE_GET_START",
   "component_id": "https://ci-storage.account.gov.uk",
+  "client_id": "NO_IPVCI_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/IPVPass/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/IPVPass/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_PASSPORT_CRI_START",
   "component_id": "IPV-Pass",
+  "client_id": "NO_PASSPORT_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/KBV/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/KBV/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_KBV_CRI_START",
   "component_id": "https://review-k.integration.account.gov.uk",
+  "client_id": "NO_KBV_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/KBVAddress/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/KBVAddress/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_ADDRESS_CRI_START",
   "component_id": "https://review-a.staging.account.gov.uk",
+  "client_id": "NO_ADDRESS_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/lambda_through_to_s3.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/lambda_through_to_s3.json
@@ -1,6 +1,6 @@
 {
   "event_id": "529f-dece-615e-FRUD",
-  "client_id": "NO_FRAUD_CLIENT_ID_YET",
+
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_FRAUD_CRI_START",

--- a/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/lambda_through_to_s3.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/lambda_through_to_s3.json
@@ -1,6 +1,6 @@
 {
   "event_id": "529f-dece-615e-FRUD",
-
+  "client_id": "NO_FRAUD_CLIENT_ID_YET",
   "timestamp": 1647969131,
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_FRAUD_CRI_START",

--- a/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/KBVFraud/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_FRAUD_CRI_START",
   "component_id": "https://review-f.integration.account.gov.uk",
+  "client_id": "NO_FRAUD_CLIENT_ID_YET",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/SNSFilterTests/perf_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/SNSFilterTests/perf_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR",
   "component_id": "",
+  "client_id": "IPV",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/SNSFilterTests/perf_expected_random.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/SNSFilterTests/perf_expected_random.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "AUTH_UPDATE_CLIENT_REQUEST_ERROR_random",
   "component_id": "",
+  "client_id": "IPV",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/SPOT/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/SPOT/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_SPOT_REQUEST_RECEIVED",
   "component_id": "SPOT",
+  "client_id": "LIoRNRhQdrConfnHyojentDo3KwFDgxN",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }

--- a/tests/event-processing-tests/src/test/resources/Test Data/lambdaToCloudwatchTests/perf_s3_expected.json
+++ b/tests/event-processing-tests/src/test/resources/Test Data/lambdaToCloudwatchTests/perf_s3_expected.json
@@ -4,5 +4,9 @@
   "timestamp_formatted": "2022-03-22T17:12:11.000Z",
   "event_name": "IPV_JOURNEY_START",
   "component_id": "",
+  "client_id": "IPV",
+  "user": {
+    "govuk_signin_journey_id": "915b-e4a4-6bg2-b8dd"
+  },
   "reIngestCount": 0
 }


### PR DESCRIPTION
This is to keep in line with the new decision authorised by IA to allow all events to be traced back to the original event - and hence, to the original client_id