### PR TITLE
Tma 640 fix audit build pipeline v2 - fix logging

### DIFF
--- a/tests/audit-tests/src/test/java/uk/gov/di/txma/audit/utilities/Driver.java
+++ b/tests/audit-tests/src/test/java/uk/gov/di/txma/audit/utilities/Driver.java
@@ -60,10 +60,10 @@ public class Driver {
                     // chromeOptions.addArguments("--remote-debugging-port=9222");
 
                     if (System.getenv("DRIVER").equals("http://selenium-hub:4444/wd/hub")) {
-                        LOGGER.info("using selenium grid to run the tests");
+                        System.out.println("[INFO]: using selenium grid remotedriver to run the tests");
                         driverPool.set(new RemoteWebDriver(new URL(System.getenv("DRIVER")), chromeOptions));
                     } else {
-                        LOGGER.info("using selenium chromedriver to run the tests");
+                        System.out.println("[INFO]: using selenium chromedriver to run the tests");
                         driverPool.set(new ChromeDriver(chromeOptions));
                     }
 


### PR DESCRIPTION
use `System.out.println()` for logging which driver is being used as java logger does not show up in codebuild logs