### PR TITLE
Add rule to delete test data automatically

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -894,6 +894,16 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref TemporaryMessageBucketLogsBucket
         LogFilePrefix: 'audit/temporary-message-batch-bucket/'
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteAutoTestObjects
+            Status: Enabled
+            ExpirationInDays: 1
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            TagFilters:
+              - Key: autoTest
+                Value: 'true'
       NotificationConfiguration:
         QueueConfigurations:
           - Event: 's3:ObjectCreated:*'
@@ -950,6 +960,14 @@ Resources:
             Transitions:
               - TransitionInDays: 90
                 StorageClass: GLACIER
+          - Id: DeleteAutoTestObjects
+            Status: Enabled
+            ExpirationInDays: 1
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            TagFilters:
+              - Key: autoTest
+                Value: 'true'
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred


### PR DESCRIPTION
The new temporary and permanent buckets used for encryption work need lifecycle rules so we can automatically delete data tagged as test data. We previously had this set up for the existing audit bucket.