### PR TITLE
Fix malformed config in MessageBatchBucket

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -202,10 +202,13 @@ Resources:
             Queue: !GetAtt AuditFileReadyToEncryptQueue.Arn
           - !If
             - IsProductionOrStaging
-            - - Event: 's3:ObjectCreated:*'
-                Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
-              - Event: 's3:ObjectRestore:*'
-                Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
+            - Event: 's3:ObjectCreated:*'
+              Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
+            - !Ref AWS::NoValue
+          - !If
+            - IsProductionOrStaging
+            - Event: 's3:ObjectRestore:*'
+              Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
             - !Ref AWS::NoValue
       OwnershipControls:
         Rules:


### PR DESCRIPTION
It looks as if the previous condition on the MessageBatchBucket that set up some queue configuration was malformed, so this is an attempt to fix it. I couldn't see a way to get multiple entries in a YAML list to have a condition, so I just added it twice.