### PR TITLE
Add dependency on Audit buckets to Queue policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -761,7 +761,7 @@ Resources:
                 - s3.amazonaws.com
             Condition:
               ArnLike:
-                aws:SourceArn: !Sub 'arn:aws:s3:*:*:${AWS::StackName}-${Environment}-temporary-message-batch'
+                aws:SourceArn: !GetAtt TemporaryMessageBatchBucket.Arn
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
           - Effect: 'Allow'
@@ -774,7 +774,7 @@ Resources:
                 - s3.amazonaws.com
             Condition:
               ArnLike:
-                aws:SourceArn: !Sub 'arn:aws:s3:*:*:${AWS::StackName}-${Environment}-message-batch'
+                aws:SourceArn: !GetAtt MessageBatchBucket.Arn
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
 


### PR DESCRIPTION
There is no enforced dependency on the S3 Buckets to exist in the queue policy. This might be causing the failures in the build account we are seeing.