### PR TITLE
Allow encrypt function to write to subfolders

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -953,6 +953,7 @@ Resources:
                   - s3:PutObject
                 Resource:
                   - !GetAtt PermanentMessageBatchBucket.Arn
+                  - !Sub '${PermanentMessageBatchBucket.Arn}/*'
               - Sid: UseSqsKmsKey
                 Effect: Allow
                 Action:


### PR DESCRIPTION
Audit files are always in a subfolder of the audit batch bucket, so we need to be able to write to the equivalent location for the permanent bucket when encrypting.

This problem originally surfaced when trying to run integration tests for ticf-integration in `build`