### PR TITLE
Remove ObjectCreated event to CSLS link.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -204,11 +204,6 @@ Resources:
             Queue: !GetAtt AuditFileReadyToEncryptQueue.Arn
           - !If
             - IsProductionOrStaging
-            - Event: 's3:ObjectCreated:*'
-              Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
-            - !Ref AWS::NoValue
-          - !If
-            - IsProductionOrStaging
             - Event: 's3:ObjectRestore:*'
               Queue: '{{resolve:ssm:CSLSS3QueueARN}}'
             - !Ref AWS::NoValue


### PR DESCRIPTION
This has been found to not be necessary, following discussions with Cyber and existing members of the TxMA team, and clashes with our need to notify the encrypt lambda.