### PR TITLE
Chore/add s3 expiration rule

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -37,13 +37,12 @@ Conditions:
       !Equals [!Ref Environment, staging],
       !Equals [!Ref Environment, production]
     ]
-  IsStaging: !Equals [!Ref Environment, staging]
   IsProduction: !And
     - !Not [!Equals [!Ref Environment, dev]]
     - !Not [!Equals [!Ref Environment, build]]
-    - !Not [!Condition IsStaging]
+    - !Not [!Equals [!Ref Environment, staging]]
   IsProductionOrStaging: !Or
-    - !Condition IsStaging
+    - !Equals [!Ref Environment, staging]
     - !Condition IsProduction
   IsPipelineTestStage: !Or
     - !Equals [!Ref Environment, build]
@@ -206,15 +205,15 @@ Resources:
                 StorageClass: GLACIER
           - !If
             - IsProduction
-            - Id: ProductionGlacierAndExpirationRule
+            - Id: ProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
             - !Ref AWS::NoValue
           - !If
-            - IsStaging
-            - Id: StagingGlacierAndExpirationRule
+            - IsTestableEnv
+            - Id: NonProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
@@ -842,15 +841,15 @@ Resources:
                 Value: 'true'
           - !If
             - IsProduction
-            - Id: ProductionGlacierAndExpirationRule
+            - Id: ProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
             - !Ref AWS::NoValue
           - !If
-            - IsStaging
-            - Id: StagingGlacierAndExpirationRule
+            - IsTestableEnv
+            - Id: NonProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
@@ -917,15 +916,15 @@ Resources:
                 StorageClass: GLACIER
           - !If
             - IsProduction
-            - Id: ProductionGlacierAndExpirationRule
+            - Id: ProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
             - !Ref AWS::NoValue
           - !If
-            - IsStaging
-            - Id: StagingGlacierAndExpirationRule
+            - IsTestableEnv
+            - Id: NonProductionExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:

--- a/template.yaml
+++ b/template.yaml
@@ -204,6 +204,8 @@ Resources:
             - Id: ProductionAuditGlacierRule
               Status: Enabled
               ExpirationInDays: 2557
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
               Transitions:
                 - TransitionInDays: 90
                   StorageClass: GLACIER
@@ -212,6 +214,8 @@ Resources:
             - Id: StagingAuditGlacierRule
               Status: Enabled
               ExpirationInDays: 120
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
               Transitions:
                 - TransitionInDays: 90
                   StorageClass: GLACIER

--- a/template.yaml
+++ b/template.yaml
@@ -37,9 +37,14 @@ Conditions:
       !Equals [!Ref Environment, staging],
       !Equals [!Ref Environment, production]
     ]
-  IsProductionOrStaging: !And
+  IsStaging: !Equals [!Ref Environment, staging]
+  IsProduction: !And
     - !Not [!Equals [!Ref Environment, dev]]
     - !Not [!Equals [!Ref Environment, build]]
+    - !Not [!Condition IsStaging]
+  IsProductionOrStaging: !And
+    - !Condition IsStaging
+    - !Condition IsProduction
   IsPipelineTestStage: !Or
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
@@ -194,11 +199,22 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-message-batch/
       LifecycleConfiguration:
         Rules:
-          - Id: AuditGlacierRule
-            Status: Enabled
-            Transitions:
-              - TransitionInDays: 90
-                StorageClass: GLACIER
+          - !If
+            - IsProduction
+            - Id: ProductionAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 2557
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
+          - !If
+            - IsStaging
+            - Id: StagingAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 120
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: s3:ObjectRestore:Completed

--- a/template.yaml
+++ b/template.yaml
@@ -215,6 +215,9 @@ Resources:
               Transitions:
                 - TransitionInDays: 90
                   StorageClass: GLACIER
+          - Id: DeleteExpiredObjects
+            Status: Enabled
+            ExpiredObjectDeleteMarker: true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: s3:ObjectRestore:Completed

--- a/template.yaml
+++ b/template.yaml
@@ -201,7 +201,7 @@ Resources:
         Rules:
           - !If
             - IsProduction
-            - Id: ProductionAuditGlacierRule
+            - Id: ProductionGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
@@ -211,7 +211,7 @@ Resources:
                   StorageClass: GLACIER
           - !If
             - IsStaging
-            - Id: StagingAuditGlacierRule
+            - Id: StagingGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
@@ -219,7 +219,7 @@ Resources:
               Transitions:
                 - TransitionInDays: 90
                   StorageClass: GLACIER
-          - Id: DeleteExpiredObjects
+          - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
       NotificationConfiguration:
@@ -836,7 +836,7 @@ Resources:
                 Value: 'true'
           - !If
             - IsProduction
-            - Id: ProductionAuditGlacierRule
+            - Id: ProductionGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
@@ -846,7 +846,7 @@ Resources:
                   StorageClass: GLACIER
           - !If
             - IsStaging
-            - Id: StagingAuditGlacierRule
+            - Id: StagingGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
@@ -854,7 +854,7 @@ Resources:
               Transitions:
                 - TransitionInDays: 90
                   StorageClass: GLACIER
-          - Id: DeleteExpiredObjects
+          - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
       NotificationConfiguration:
@@ -910,7 +910,7 @@ Resources:
         Rules:
           - !If
             - IsProduction
-            - Id: ProductionAuditGlacierRule
+            - Id: ProductionGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
@@ -920,7 +920,7 @@ Resources:
                   StorageClass: GLACIER
           - !If
             - IsStaging
-            - Id: StagingAuditGlacierRule
+            - Id: StagingGlacierAndExpirationRule
               Status: Enabled
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
@@ -936,7 +936,7 @@ Resources:
             TagFilters:
               - Key: autoTest
                 Value: 'true'
-          - Id: DeleteExpiredObjects
+          - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
       OwnershipControls:

--- a/template.yaml
+++ b/template.yaml
@@ -42,7 +42,7 @@ Conditions:
     - !Not [!Equals [!Ref Environment, dev]]
     - !Not [!Equals [!Ref Environment, build]]
     - !Not [!Condition IsStaging]
-  IsProductionOrStaging: !And
+  IsProductionOrStaging: !Or
     - !Condition IsStaging
     - !Condition IsProduction
   IsPipelineTestStage: !Or

--- a/template.yaml
+++ b/template.yaml
@@ -199,6 +199,11 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-message-batch/
       LifecycleConfiguration:
         Rules:
+          - Id: AuditGlacierRule
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 90
+                StorageClass: GLACIER
           - !If
             - IsProduction
             - Id: ProductionGlacierAndExpirationRule
@@ -206,9 +211,7 @@ Resources:
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - !If
             - IsStaging
             - Id: StagingGlacierAndExpirationRule
@@ -216,9 +219,7 @@ Resources:
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
@@ -826,6 +827,11 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-temporary-message-batch/
       LifecycleConfiguration:
         Rules:
+          - Id: AuditGlacierRule
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 90
+                StorageClass: GLACIER
           - Id: DeleteAutoTestObjects
             Status: Enabled
             ExpirationInDays: 1
@@ -841,9 +847,7 @@ Resources:
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - !If
             - IsStaging
             - Id: StagingGlacierAndExpirationRule
@@ -851,9 +855,7 @@ Resources:
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
@@ -908,6 +910,11 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-permanent-message-batch/
       LifecycleConfiguration:
         Rules:
+          - Id: AuditGlacierRule
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 90
+                StorageClass: GLACIER
           - !If
             - IsProduction
             - Id: ProductionGlacierAndExpirationRule
@@ -915,9 +922,7 @@ Resources:
               ExpirationInDays: 2557
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - !If
             - IsStaging
             - Id: StagingGlacierAndExpirationRule
@@ -925,9 +930,7 @@ Resources:
               ExpirationInDays: 120
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
-              Transitions:
-                - TransitionInDays: 90
-                  StorageClass: GLACIER
+            - !Ref AWS::NoValue
           - Id: DeleteAutoTestObjects
             Status: Enabled
             ExpirationInDays: 1

--- a/template.yaml
+++ b/template.yaml
@@ -834,6 +834,29 @@ Resources:
             TagFilters:
               - Key: autoTest
                 Value: 'true'
+          - !If
+            - IsProduction
+            - Id: ProductionAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 2557
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
+          - !If
+            - IsStaging
+            - Id: StagingAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 120
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
+          - Id: DeleteExpiredObjects
+            Status: Enabled
+            ExpiredObjectDeleteMarker: true
       NotificationConfiguration:
         QueueConfigurations:
           - Event: 's3:ObjectCreated:*'
@@ -885,11 +908,26 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-permanent-message-batch/
       LifecycleConfiguration:
         Rules:
-          - Id: AuditGlacierRule
-            Status: Enabled
-            Transitions:
-              - TransitionInDays: 90
-                StorageClass: GLACIER
+          - !If
+            - IsProduction
+            - Id: ProductionAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 2557
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
+          - !If
+            - IsStaging
+            - Id: StagingAuditGlacierRule
+              Status: Enabled
+              ExpirationInDays: 120
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 30
+              Transitions:
+                - TransitionInDays: 90
+                  StorageClass: GLACIER
           - Id: DeleteAutoTestObjects
             Status: Enabled
             ExpirationInDays: 1
@@ -898,6 +936,9 @@ Resources:
             TagFilters:
               - Key: autoTest
                 Value: 'true'
+          - Id: DeleteExpiredObjects
+            Status: Enabled
+            ExpiredObjectDeleteMarker: true
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred


### PR DESCRIPTION
Expand lifecycle configuration rules for MessageBatch and Permanent buckets to expire objects after 7 years and deleted expired objects after 30 days.