### PR TITLE
Enable feature branch deployments - Part 5

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1023,10 +1023,10 @@ Resources:
     Type: AWS::SNS::Subscription
     Properties:
       TopicArn: '{{resolve:ssm:EventProcessorSNSTopicARN}}'
-      Endpoint: !GetAtt AuditDeliveryStream.Arn
+      Endpoint: !GetAtt AuditMessageDeliveryStream.Arn
       Protocol: firehose
       RawMessageDelivery: true
-      SubscriptionRoleArn: !GetAtt SNSTopicSubscriptionRole.Arn
+      SubscriptionRoleArn: !GetAtt AuditMessageDeliveryEventProcessingSnsSubscriptionRole.Arn
 
   DeliveryStreamPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
This PR swaps the SNS subscription to the new Firehose delivery stream. So all the new resources will now be in use. A follow up PR will then be raised to delete the old resources.