### PR TITLE
Enable feature branch deployments - Part 6

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -253,27 +253,6 @@ Resources:
       MetricsConfigurations:
         - Id: EntireBucket
 
-  TemporaryMessageBatchBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref TemporaryMessageBatchBucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowBucketAccess
-            Effect: Allow
-            Action:
-              - s3:GetObject
-              - s3:DeleteObject
-            Resource:
-              - !GetAtt TemporaryMessageBatchBucket.Arn
-              - !Sub '${TemporaryMessageBatchBucket.Arn}/*'
-            Principal:
-              AWS: !GetAtt InitiateCopyAndEncryptLambdaRole.Arn
-            Condition:
-              Bool:
-                'aws:SecureTransport': 'true'
-
   PermanentMessageBatchBucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -331,26 +310,6 @@ Resources:
           - ObjectOwnership: BucketOwnerPreferred
       MetricsConfigurations:
         - Id: EntireBucket
-
-  PermanentMessageBatchBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref PermanentMessageBatchBucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowPermanentBucketAccess
-            Effect: 'Allow'
-            Action:
-              - 's3:PutObject'
-            Resource:
-              - !GetAtt PermanentMessageBatchBucket.Arn
-              - !Sub '${PermanentMessageBatchBucket.Arn}/*'
-            Principal:
-              AWS: !GetAtt InitiateCopyAndEncryptLambdaRole.Arn
-            Condition:
-              Bool:
-                'aws:SecureTransport': 'true'
 
   MessageBatchBucketTxMA2:
     Type: AWS::S3::Bucket
@@ -472,13 +431,6 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/encryption-generator-kms-key
       TargetKeyId: !Ref EncryptionGeneratorKmsKey
 
-  EncryptionGeneratorKmsKeyArnParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: EncryptionGeneratorKmsKeyArn
-      Type: String
-      Value: !GetAtt EncryptionGeneratorKmsKey.Arn
-
   S3EncryptionGeneratorKmsKeyArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -539,30 +491,6 @@ Resources:
                 aws:SourceAccount: !Ref AWS::AccountId
 
   # Lambda resources
-  InitiateCopyAndEncryptFunction:
-    #checkov:skip=CKV_AWS_115:Defined in Globals section
-    Type: AWS::Serverless::Function
-    Properties:
-      MemorySize: 1536
-      FunctionName: InitiateCopyAndEncryptFunction
-      Handler: s3CopyAndEncrypt.handler
-      Role: !GetAtt InitiateCopyAndEncryptLambdaRole.Arn
-      KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
-      Environment:
-        Variables:
-          TEMPORARY_BUCKET_NAME: !Ref TemporaryMessageBatchBucket
-          PERMANENT_BUCKET_NAME: !Ref PermanentMessageBatchBucket
-          AUDIT_BUCKET_NAME: !Ref MessageBatchBucket
-          GENERATOR_KEY_ID: !GetAtt EncryptionGeneratorKmsKey.Arn
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-    DeadLetterQueue:
-      Type: SQS
-      TargetArn: !GetAtt AuditFileReadyToEncryptDeadLetterQueue.Arn
-
   S3CopyAndEncryptFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
     Type: AWS::Serverless::Function
@@ -590,40 +518,12 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
 
-  InitiateCopyAndEncryptLogs:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
-      LogGroupName: !Sub '/aws/lambda/InitiateCopyAndEncryptFunction'
-      RetentionInDays: 7
-
   S3CopyAndEncryptLogs:
     Type: AWS::Logs::LogGroup
     Properties:
       KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-s3-copy-and-encrypt
       RetentionInDays: 7
-
-  InitiateCopyAndEncryptLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub '${AWS::StackName}-LambdaAccessRole-InitiateCopyAndEncrypt'
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: ''
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action: 'sts:AssumeRole'
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-        - !Ref InitiateCopyAndEncryptPolicy
 
   S3CopyAndEncryptFunctionRole:
     Type: AWS::IAM::Role
@@ -645,63 +545,6 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - !Ref S3CopyAndEncryptPolicy
-
-  InitiateCopyAndEncryptPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: !Sub ${AWS::StackName}-InitiateCopyAndEncryptPolicy
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: TemporaryS3Read
-            Effect: Allow
-            Action:
-              - s3:GetObject
-            Resource:
-              - !GetAtt TemporaryMessageBatchBucket.Arn
-              - !Sub '${TemporaryMessageBatchBucket.Arn}/*'
-          - Sid: AuditS3Read
-            Effect: Allow
-            Action:
-              - s3:GetObject
-            Resource:
-              - !GetAtt MessageBatchBucket.Arn
-              - !Sub '${MessageBatchBucket.Arn}/*'
-          - Sid: PermanentS3Write
-            Effect: Allow
-            Action:
-              - s3:PutObject
-            Resource:
-              - !GetAtt PermanentMessageBatchBucket.Arn
-              - !Sub '${PermanentMessageBatchBucket.Arn}/*'
-          - Sid: UseSqsKmsKey
-            Effect: Allow
-            Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey*
-              - kms:ReEncrypt*
-            Resource:
-              - !GetAtt AuditFileReadyToEncryptQueueKmsKey.Arn
-          - Sid: Logs
-            Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-            Resource: !GetAtt InitiateCopyAndEncryptLogs.Arn
-          - Sid: sqsReceive
-            Effect: Allow
-            Action:
-              - sqs:*
-            Resource: !GetAtt AuditFileReadyToEncryptQueue.Arn
-          - Sid: UseEncryptionGeneratorKmsKey
-            Effect: Allow
-            Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey*
-              - kms:Encrypt*
-            Resource:
-              - !GetAtt EncryptionGeneratorKmsKey.Arn
 
   S3CopyAndEncryptPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -838,40 +681,12 @@ Resources:
   ##########################################
 
   # Lambda function resources
-  DelimiterLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
-      LogGroupName: /aws/lambda/DelimiterFunction
-      RetentionInDays: 7
-
   AuditMessageDelimiterLogs:
     Type: AWS::Logs::LogGroup
     Properties:
       KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-audit-message-delimiter
       RetentionInDays: 7
-
-  DelimiterLambdaAccessRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub ${AWS::StackName}-LambdaAccessRole-Delimiter
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowLambdaServiceToAssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
 
   AuditMessageDelimiterFunctionRole:
     Type: AWS::IAM::Role
@@ -894,21 +709,6 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
 
-  DelimiterFunction:
-    #checkov:skip=CKV_AWS_115:Defined in Globals section
-    Type: AWS::Serverless::Function
-    Properties:
-      MemorySize: 256
-      FunctionName: DelimiterFunction
-      Handler: auditMessageDelimiter.handler
-      Role: !GetAtt DelimiterLambdaAccessRole.Arn
-      KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-
   AuditMessageDelimiterFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
     Type: AWS::Serverless::Function
@@ -925,13 +725,6 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
 
   # Kinesis Firehose resources
-  FirehoseLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
-      LogGroupName: /aws/firehose
-      RetentionInDays: 7
-
   AuditMessageDeliveryStreamLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -939,52 +732,11 @@ Resources:
       LogGroupName: !Sub /aws/kinesisfirehose/${AWS::StackName}-message-batch
       RetentionInDays: 7
 
-  FirehoseLogStream:
-    Type: AWS::Logs::LogStream
-    Properties:
-      LogGroupName: !Ref FirehoseLogGroup
-      LogStreamName: audit
-
   AuditMessageDeliveryStreamDestinationLogStream:
     Type: AWS::Logs::LogStream
     Properties:
       LogGroupName: !Ref AuditMessageDeliveryStreamLogs
       LogStreamName: DestinationDelivery
-
-  AuditDeliveryStream:
-    Type: AWS::KinesisFirehose::DeliveryStream
-    DependsOn:
-      - DeliveryStreamPolicy
-    Properties:
-      DeliveryStreamName: !Sub AuditFireHose-${Environment}
-      DeliveryStreamType: DirectPut
-      DeliveryStreamEncryptionConfigurationInput:
-        KeyARN: '{{resolve:ssm:FirehoseKmsKeyArn}}'
-        KeyType: CUSTOMER_MANAGED_CMK
-      ExtendedS3DestinationConfiguration:
-        Prefix: firehose/
-        BucketARN: !GetAtt MessageBatchBucket.Arn
-        BufferingHints:
-          IntervalInSeconds: !If
-            - IsTestableEnv
-            - 60
-            - 900
-          SizeInMBs: 128
-        CompressionFormat: GZIP
-        RoleARN: !GetAtt DeliveryStreamRole.Arn
-        CloudWatchLoggingOptions:
-          Enabled: true
-          LogGroupName: !Ref FirehoseLogGroup
-          LogStreamName: !Ref FirehoseLogStream
-        ProcessingConfiguration:
-          Enabled: true
-          Processors:
-            - Type: Lambda
-              Parameters:
-                - ParameterName: LambdaArn
-                  ParameterValue: !GetAtt DelimiterFunction.Arn
-                - ParameterName: RoleArn
-                  ParameterValue: !GetAtt DeliveryStreamRole.Arn
 
   AuditMessageDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
@@ -1004,7 +756,7 @@ Resources:
             - 900
           SizeInMBs: 128
         CompressionFormat: GZIP
-        RoleARN: !GetAtt DeliveryStreamRole.Arn # TODO: Update
+        RoleARN: !GetAtt AuditMessageDeliveryStreamRole.Arn
         CloudWatchLoggingOptions:
           Enabled: true
           LogGroupName: !Ref AuditMessageDeliveryStreamLogs
@@ -1027,39 +779,6 @@ Resources:
       Protocol: firehose
       RawMessageDelivery: true
       SubscriptionRoleArn: !GetAtt AuditMessageDeliveryEventProcessingSnsSubscriptionRole.Arn
-
-  DeliveryStreamPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      Roles:
-        - !Ref DeliveryStreamRole
-      PolicyName: firehose_delivery_policy
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - s3:AbortMultipartUpload
-              - s3:GetBucketLocation
-              - s3:GetObject
-              - s3:ListBucket
-              - s3:ListBucketMultipartUploads
-              - s3:PutObject
-            Resource:
-              - !GetAtt MessageBatchBucket.Arn
-              - !Sub ${MessageBatchBucket.Arn}/*
-          - Effect: Allow
-            Action:
-              - lambda:InvokeFunction
-              - lambda:GetFunctionConfiguration
-            Resource: !Sub ${DelimiterFunction.Arn}*
-          - Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:PutLogEvents
-              - logs:CreateLogStream
-            Resource:
-              - !GetAtt FirehoseLogGroup.Arn
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -1093,23 +812,6 @@ Resources:
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
 
-  DeliveryStreamRole:
-    Type: AWS::IAM::Role
-    Properties:
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowFirehoseToAssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - firehose.amazonaws.com
-            Action: sts:AssumeRole
-
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1130,25 +832,6 @@ Resources:
       ManagedPolicyArns:
         - !Ref AuditMessageDeliveryStreamPolicy
 
-  SNSTopicSubscriptionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - sns.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      ManagedPolicyArns:
-        - !Ref SnsKinesisFirehoseAccessPolicy
-
   AuditMessageDeliveryEventProcessingSnsSubscriptionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1168,27 +851,6 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - !Ref AuditMessageDeliveryEventProcessingSnsSubscriptionPolicy
-
-  SnsKinesisFirehoseAccessPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: sns_kinesis_firehose_access_policy
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - 'firehose:DescribeDeliveryStream'
-              - 'firehose:ListDeliveryStreams'
-              - 'firehose:ListTagsForDeliveryStream'
-              - 'firehose:PutRecord'
-              - 'firehose:PutRecordBatch'
-            Resource:
-              - !GetAtt AuditDeliveryStream.Arn
-          - Effect: Allow
-            Action:
-              - 'kms:Decrypt'
-            Resource: '{{resolve:ssm:SNSKMSKeyARN}}'
 
   AuditMessageDeliveryEventProcessingSnsSubscriptionPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -1243,15 +905,6 @@ Resources:
   # Start: CSLS Subscriptions #
   #############################
 
-  CSLSFireHoseLogsSubscription:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsProductionOrStaging
-    Properties:
-      LogGroupName:
-        Ref: FirehoseLogGroup
-      FilterPattern: ''
-      DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
-
   CslsAuditMessageDeliveryStreamLogsSubscription:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsProductionOrStaging
@@ -1260,29 +913,11 @@ Resources:
       FilterPattern: ''
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
-  CSLSDelimiterLogsSubscription:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsProductionOrStaging
-    Properties:
-      LogGroupName:
-        Ref: DelimiterLogGroup
-      FilterPattern: ''
-      DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
-
   CslsAuditMessageDelimiterFunctionSubscription:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsProductionOrStaging
     Properties:
       LogGroupName: !Ref AuditMessageDelimiterLogs
-      FilterPattern: ''
-      DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
-
-  CSLSInitiateCopyAndEncryptLogsSubscription:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsProductionOrStaging
-    Properties:
-      LogGroupName:
-        Ref: InitiateCopyAndEncryptLogs
       FilterPattern: ''
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
@@ -1303,27 +938,6 @@ Resources:
   ##########################################
 
   # CloudWatch Alarms
-  FailureToEncryptAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmDescription: Alarm that monitors the ReadToEncrypt DLQ for any new objects
-      AlarmName: FailureToEncryptAlarm
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      Statistic: Sum
-      Period: 60
-      Threshold: 1
-      TreatMissingData: notBreaching
-      MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
-      AlarmActions:
-        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
-      OKActions:
-        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
-      Dimensions:
-        - Name: QueueName
-          Value: !GetAtt AuditFileReadyToEncryptDeadLetterQueue.QueueName
-
   FailureToEncryptAuditMessageAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1344,27 +958,6 @@ Resources:
       Dimensions:
         - Name: QueueName
           Value: !GetAtt AuditFileReadyToEncryptDeadLetterQueue.QueueName
-
-  S3NoReceivedObjectsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmDescription: Audit S3 Received No Objects Alarm
-      AlarmName: S3NoReceivedObjectsAlarm
-      ComparisonOperator: LessThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      Statistic: Sum
-      Period: 86400
-      Threshold: 0
-      TreatMissingData: breaching
-      MetricName: PutRequests
-      Namespace: AWS/S3
-      AlarmActions:
-        - '{{resolve:ssm:CriticalAlarmSnsTopicArn}}'
-      Dimensions:
-        - Name: BucketName
-          Value: !Ref MessageBatchBucket
-        - Name: FilterId
-          Value: EntireBucket
 
   NoAuditMessagesReceivedAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
* Removes old resources that are no longer used.
* Fixes an instance where the new delivery stream was referencing the old IAM role - causes no issues since the new role and the old role had the same permissions
* It also removes the bucket policies on the Temporary and Permanent buckets - these were also referencing the old Encrypt Lambda ARNs. Thought this would have caused an issue. However, the permissions the Bucket policy provided exist on the Lambda function role anyway. Assume these policies are leftover from a time where things were a bit different, seeing as the permissions reference a delete which no longer happens. Thought it best to remove the policies so the permissions are only defined in one place