### PR TITLE
Add new Event Processor SNS subscription

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -702,6 +702,15 @@ Resources:
       RawMessageDelivery: true
       SubscriptionRoleArn: !GetAtt AuditMessageDeliveryEventProcessingSnsSubscriptionRole.Arn
 
+  AuditMessageDeliveryStreamSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: '{{resolve:ssm:EventProcessorSnsTopicArn}}'
+      Endpoint: !GetAtt AuditMessageDeliveryStream.Arn
+      Protocol: firehose
+      RawMessageDelivery: true
+      SubscriptionRoleArn: !GetAtt AuditMessageDeliveryEventProcessingSnsSubscriptionRole.Arn
+
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
* Adds new SNS subscription to the new Event Processor topic - this topic is currently not active, but needs to be there until we swap it to active in the Event Processor repo