### PR TITLE
Add DLQ to Audit Message Delimiter function

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -633,15 +633,25 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
 
+  AuditMessageDelimiterDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${AWS::StackName}-audit-message-delimiter-dlq
+      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
+      MessageRetentionPeriod: 1209600
+
   AuditMessageDelimiterFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
     Type: AWS::Serverless::Function
     Properties:
-      MemorySize: 256
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
       FunctionName: !Sub ${AWS::StackName}-audit-message-delimiter
       Handler: auditMessageDelimiter.handler
-      Role: !GetAtt AuditMessageDelimiterFunctionRole.Arn
       KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
+      MemorySize: 256
+      Role: !GetAtt AuditMessageDelimiterFunctionRole.Arn
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
@@ -838,6 +848,27 @@ Resources:
   ##########################################
 
   # CloudWatch Alarms
+  AuditMessageDelimiterDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Monitor Audit Message Delimiter function DLQ for messages. 
+        Indicates Audit messages have not been delivered to the Audit bucket.
+      AlarmName: !Sub ${AWS::StackName}-audit-message-dlq
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt AuditMessageDelimiterDeadLetterQueue.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+
   FailureToEncryptAuditMessageAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -869,8 +869,9 @@ Resources:
       AlarmActions:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
-        Monitor Audit Message Delimiter function DLQ for messages. 
-        Indicates Audit messages have not been delivered to the Audit bucket.
+        Monitor Audit Message Delimiter function DLQ for new messages. 
+        When messages land in this queue, it indicates Audit events 
+        have not been delivered to the Audit bucket.
       AlarmName: !Sub ${AWS::StackName}-audit-message-dlq
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -887,44 +888,45 @@ Resources:
   FailureToEncryptAuditMessageAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Alarm that monitors the ReadToEncrypt DLQ for any new objects
-      AlarmName: !Sub ${AWS::StackName}-failure-to-encrypt-audit-message
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      Statistic: Sum
-      Period: 60
-      Threshold: 1
-      TreatMissingData: notBreaching
-      MetricName: ApproximateNumberOfMessagesVisible
-      Namespace: AWS/SQS
       AlarmActions:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
-      OKActions:
-        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Monitor the Ready To Encrypt DLQ for new messages. 
+        When messages land in this queue, it indicates Audit events have 
+        failed to encrypt.
+      AlarmName: !Sub ${AWS::StackName}-failure-to-encrypt-audit-message
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
       Dimensions:
         - Name: QueueName
           Value: !GetAtt AuditFileReadyToEncryptDeadLetterQueue.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Sum
+      Period: 60
+      Threshold: 0
 
   NoAuditMessagesReceivedAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmActions:
+        - '{{resolve:ssm:CriticalAlarmSnsTopicArn}}'
       AlarmDescription: Audit S3 Received No Objects Alarm
       AlarmName: !Sub ${AWS::StackName}-no-audit-messages-received
       ComparisonOperator: LessThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      Statistic: Sum
-      Period: 43200
-      Threshold: 0
-      TreatMissingData: breaching
-      MetricName: PutRequests
-      Namespace: AWS/S3
-      AlarmActions:
-        - '{{resolve:ssm:CriticalAlarmSnsTopicArn}}'
       Dimensions:
         - Name: BucketName
           Value: !Ref MessageBatchBucket
         - Name: FilterId
           Value: EntireBucket
+      EvaluationPeriods: 1
+      MetricName: PutRequests
+      Namespace: AWS/S3
+      Period: 43200
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: breaching
 
   # PagerDuty
   PagerDutySubscription:

--- a/template.yaml
+++ b/template.yaml
@@ -659,9 +659,11 @@ Resources:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
     Type: AWS::Serverless::Function
     Properties:
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
+      EventInvokeConfiguration:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Queue: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
       FunctionName: !Sub ${AWS::StackName}-audit-message-delimiter
       Handler: auditMessageDelimiter.handler
       KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -377,7 +377,7 @@ Resources:
     Properties:
       QueueName: !Sub ${AWS::StackName}-${Environment}-audit-file-ready-to-encrypt-DLQ
       KmsMasterKeyId: '{{resolve:ssm:AuditFileReadyToEncryptQueueKmsKeyArn}}'
-      MessageRetentionPeriod: 1209600
+      MessageRetentionPeriod: 1209600 # 14 days
 
   AuditFileReadyToEncryptQueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/template.yaml
+++ b/template.yaml
@@ -662,8 +662,7 @@ Resources:
       EventInvokeConfig:
         DestinationConfig:
           OnFailure:
-            Type: SQS
-            Queue: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
+            Destination: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
       FunctionName: !Sub ${AWS::StackName}-audit-message-delimiter
       Handler: auditMessageDelimiter.handler
       KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -612,6 +612,27 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-audit-message-delimiter
       RetentionInDays: 7
 
+  AuditMessageDelimiterDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${AWS::StackName}-audit-message-delimiter-dlq
+      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
+      MessageRetentionPeriod: 1209600
+
+  AuditMessageDelimiterFunctionDeadLetterQueuePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub ${AWS::StackName}-message-delimiter-dlq-policy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowDeadLetterQueueAccess
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
+
   AuditMessageDelimiterFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -632,13 +653,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-
-  AuditMessageDelimiterDeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub ${AWS::StackName}-audit-message-delimiter-dlq
-      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
-      MessageRetentionPeriod: 1209600
+        - !Ref AuditMessageDelimiterFunctionDeadLetterQueuePolicy
 
   AuditMessageDelimiterFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals section

--- a/template.yaml
+++ b/template.yaml
@@ -663,6 +663,7 @@ Resources:
         DestinationConfig:
           OnFailure:
             Destination: !GetAtt AuditMessageDelimiterDeadLetterQueue.Arn
+            Type: SQS
       FunctionName: !Sub ${AWS::StackName}-audit-message-delimiter
       Handler: auditMessageDelimiter.handler
       KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -617,7 +617,7 @@ Resources:
     Properties:
       QueueName: !Sub ${AWS::StackName}-audit-message-delimiter-dlq
       KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
-      MessageRetentionPeriod: 1209600
+      MessageRetentionPeriod: 1209600 # 14 days
 
   AuditMessageDelimiterFunctionDeadLetterQueuePolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -659,7 +659,7 @@ Resources:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
     Type: AWS::Serverless::Function
     Properties:
-      EventInvokeConfiguration:
+      EventInvokeConfig:
         DestinationConfig:
           OnFailure:
             Type: SQS


### PR DESCRIPTION
* Adds DLQ and Alarm to Audit Delivery Stream Transformation Function (AKA Delimiter function)
* Align both DLQ alarms so they use the same parameters - For these types or alarms it's best to do a X out of Y style. In our case if we get 1 data point then we want to alarm. Also have done away with the OK action, as it doesn't really serve a purpose. Once someone has finished dealing with the alarm, do we need a Slack alert?