### PR TITLE
TT2-736 audit add dlq and alarm to sns subscription

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -774,7 +774,8 @@ Resources:
           Resource:
             - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
           Condition:
-            aws:SourceArn: !GetAtt AuditMessageDeliveryStreamSubscription.Arn
+            ArnEquals:
+              aws:SourceArn: !Ref AuditMessageDeliveryStreamSubscription
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -773,8 +773,6 @@ Resources:
             - sqs:SendMessage
           Resource:
             - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
-          Condition:
-            sourceArn: !Ref AuditMessageDeliveryStreamSubscription
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -773,6 +773,8 @@ Resources:
             - sqs:SendMessage
           Resource:
             - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
+          Condition:
+            aws:SourceArn: !Ref AuditMessageDeliveryStreamSubscription
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -942,6 +942,27 @@ Resources:
       Statistic: Sum
       Threshold: 0
 
+  FailureToPublishAuditMessageDeliveryStreamSubscription:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm that monitors the AuditMessageDeliveryStream DLQ
+      AlarmName: !Sub ${AWS::StackName}-failure-to-publish-audit-stream
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Statistic: Sum
+      Period: 60
+      Threshold: 1
+      DatapointsToAlarm: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      OKActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.QueueName
+
   FailureToEncryptAuditMessageAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -756,7 +756,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${AWS::StackName}-${Environment}-audit-message-delivery-stream-DLQ
-      KmsMasterKeyId: '{{resolve:ssm:AuditFileReadyToEncryptQueueKmsKeyArn}}' #TODO: Do I need to use a different KMS key here?
+      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArnParameter}}'
       MessageRetentionPeriod: 1209600 # 14 Days
 
   AuditMessageDeliveryStreamSubscriptionDeadLetterQueuePolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -749,6 +749,32 @@ Resources:
       Protocol: firehose
       RawMessageDelivery: true
       SubscriptionRoleArn: !GetAtt AuditMessageDeliveryEventProcessingSnsSubscriptionRole.Arn
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
+
+  AuditMessageDeliveryStreamSubscriptionDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${AWS::StackName}-${Environment}-audit-message-delivery-stream-DLQ
+      KmsMasterKeyId: '{{resolve:ssm:AuditFileReadyToEncryptQueueKmsKeyArn}}' #TODO: Do I need to use a different KMS key here?
+      MessageRetentionPeriod: 1209600 # 14 Days
+
+  AuditMessageDeliveryStreamSubscriptionDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref AuditMessageDeliveryStreamSubscriptionDeadLetterQueue
+      PolicyDocument:
+        Statement:
+          Principal:
+            Service: sns.amazonaws.com
+          Effect: Allow
+          Action:
+            - sqs:SendMessage
+          Resource:
+            - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
+          Condition:
+            sourceArn: !Ref AuditMessageDeliveryStreamSubscription
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -781,6 +807,11 @@ Resources:
               - logs:CreateLogStream
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
 
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role

--- a/template.yaml
+++ b/template.yaml
@@ -774,7 +774,7 @@ Resources:
           Resource:
             - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
           Condition:
-            aws:SourceArn: !Ref AuditMessageDeliveryStreamSubscription
+            aws:SourceArn: !GetAtt AuditMessageDeliveryStreamSubscription.Arn
 
   AuditMessageDeliveryStreamPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -756,7 +756,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub ${AWS::StackName}-${Environment}-audit-message-delivery-stream-DLQ
-      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArnParameter}}'
+      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
       MessageRetentionPeriod: 1209600 # 14 Days
 
   AuditMessageDeliveryStreamSubscriptionDeadLetterQueuePolicy:

--- a/template.yaml
+++ b/template.yaml
@@ -771,6 +771,7 @@ Resources:
           Effect: Allow
           Action:
             - sqs:SendMessage
+            - sqs:GetQueueAttributes
           Resource:
             - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
           Condition:
@@ -808,11 +809,6 @@ Resources:
               - logs:CreateLogStream
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              - !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
 
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role
@@ -874,6 +870,11 @@ Resources:
             Action:
               - kms:Decrypt
             Resource: '{{resolve:ssm:EventProcessorSnsKmsKeyArn}}'
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+              - sqs:GetQueueAttributes
+            Resource: !GetAtt AuditMessageDeliveryStreamSubscriptionDeadLetterQueue.Arn
 
   ########################################
   # End: Audit delivery stream resources #


### PR DESCRIPTION
### This PR adds:

- A Dead Letter queue, `AuditMessageDeliveryStreamSubscriptionDeadLetterQueue`, for the `AuditEventDeliveryStreamSubscription` to ensure that if SNS fails to publish to firehose, their events will not be lost 
- An alarm attached to this DLQ, with slack integration, to ensure that if the number of messages on the DLQ is > 0 a message is sent to Slack 