### PR TITLE
Remove unused Kinesis policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -645,7 +645,6 @@ Resources:
                 - lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
 
   AuditMessageDelimiterFunction:


### PR DESCRIPTION
The managed policy on these functions is not required. It gives kinesis:* permissions. Which is a different service to firehose. The required permissions are attached to the role separately.