### PR TITLE
Remove unused auto test lifecycle rules

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -233,14 +233,6 @@ Resources:
             Transitions:
               - TransitionInDays: 90
                 StorageClass: GLACIER
-          - Id: DeleteAutoTestObjects
-            Status: Enabled
-            ExpirationInDays: 1
-            NoncurrentVersionExpiration:
-              NoncurrentDays: 1
-            TagFilters:
-              - Key: autoTest
-                Value: true
           - !If
             - IsProduction
             - Id: ProductionExpirationRule
@@ -311,14 +303,6 @@ Resources:
               NoncurrentVersionExpiration:
                 NoncurrentDays: 30
             - !Ref AWS::NoValue
-          - Id: DeleteAutoTestObjects
-            Status: Enabled
-            ExpirationInDays: 1
-            NoncurrentVersionExpiration:
-              NoncurrentDays: 1
-            TagFilters:
-              - Key: autoTest
-                Value: true
           - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,7 +3667,7 @@ __metadata:
     eslint-plugin-jest: 27.2.2
     husky: 8.0.3
     jest: 29.6.1
-    jest-junit: ^16.0.0
+    jest-junit: 16.0.0
     jest-when: 3.5.2
     lint-staged: 13.2.3
     prettier: 2.8.8
@@ -5114,7 +5114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-junit@npm:^16.0.0":
+"jest-junit@npm:16.0.0":
   version: 16.0.0
   resolution: "jest-junit@npm:16.0.0"
   dependencies:


### PR DESCRIPTION
Removes some lifecycle rules from the audit buckets that appear in production. These were probably copied from the TxMA 2 bucket (which only appears up to staging).