### PR TITLE
Tt2 886 audit permanent message batch bucket ssm

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1320,8 +1320,8 @@ Resources:
       Description: Audit delivery lambda available for self serve integration tests
 
   PermanentMessageBatchBucketParameter:
-    Condition: TestRoleResources
     Type: AWS::SSM::Parameter
+    Condition: TestRoleResources
     Properties:
       Name: !Sub ${AWS::StackName}-${Environment}-permanent-message-batch
       Type: String
@@ -1348,16 +1348,16 @@ Resources:
       ServiceToken: '{{resolve:ssm:EmptyS3BucketsFunctionArn}}'
 
   IntegrationTestsAddRecordToFirehoseFunctionNameParameter:
-    Condition: TestEnvironment
     Type: AWS::SSM::Parameter
+    Condition: TestEnvironment
     Properties:
       Name: !Sub /tests/${AWS::StackName}/AddRecordToFirehoseFunctionName
       Type: String
       Value: '{{resolve:ssm:/tests/AddFirehoseRecordFunctionName}}'
 
   AddRecordToFirehoseLambdaPolicy:
-    Condition: TestRoleResources
     Type: AWS::Lambda::Permission
+    Condition: TestRoleResources
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt IntegrationTestsAddRecordToFirehoseFunctionNameParameter.Value

--- a/template.yaml
+++ b/template.yaml
@@ -1319,6 +1319,15 @@ Resources:
       Value: !Ref AuditMessageDelimiterFunction
       Description: Audit delivery lambda available for self serve integration tests
 
+  PermanentMessageBatchBucketParameter:
+    Condition: TestRoleResources
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub ${AWS::StackName}-${Environment}-permanent-message-batch
+      Type: String
+      Value: !Ref PermanentMessageBatchBucket
+      Description: Audit permanent message back bucket available for event replay integration tests
+
   ############################################
   # End: Automated Test resources #
   ############################################


### PR DESCRIPTION
Added an ssm parameter to access the audit permanent message batch s3 bucket that lives in the audit stack, from the event-replay stack for the event-replay e2e test 
Rearranged other parameters to follow the same order as the rest of the template.yaml file