### PR TITLE
DPT-675 - add jest config for coverage reports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [
   {
     ignores: [
       '.aws-sam',
+      'coverage',
       'dist/',
       '/tests/',
       'node_modules',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,11 +1,35 @@
-import type { Config } from '@jest/types'
+import type { JestConfigWithTsJest } from 'ts-jest'
 
-const config: Config.InitialOptions = {
-  coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
+const baseCoverage = [
+  // scan all files
+  '<rootDir>/**/*.ts',
+  // scripts can be ignored
+  '!**/scripts/**',
+  // types can be ignored
+  '!**/interface/**',
+  '!**/interfaces/**',
+  '!**/type/**',
+  '!**/types/**',
+  // The buildLogger function doesn't have anything we can meaningfully test
+  '!**/logger.ts',
+  // ignoring the tests folder
+  '!**/tests/**',
+  // ignore config files
+  '!**/*.config.ts',
+  // ignore .files
+  '!**/.*'
+]
+
+const config: JestConfigWithTsJest = {
+  coveragePathIgnorePatterns: ['/node_modules/', '/.yarn/', '/dist/'],
   preset: 'ts-jest',
   verbose: true,
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts', '<rootDir>/common/**/*.test.ts'],
   setupFiles: ['<rootDir>/common/utils/tests/setup/testEnvVars.ts'],
-  testMatch: ['**/*.test.ts', '<rootDir>/common/**/*.test.ts']
+  collectCoverageFrom: ['Optional', 'options', 'per', 'repo'].concat(
+    baseCoverage
+  )
 }
 
 export default config


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-675

## :bulb: Description
Add test coverage reports

## :sparkles: Changes Made

edit the Jest config to include a standard coverage report for sonarQube
Add coverage reports to the ignore list for eslint etc

## :test_tube: Testing Instructions/Notes

N/A

## :frame_with_picture: Screenshots (if applicable)

<img width="1912" height="590" alt="Screenshot 2025-08-08 at 14 36 02" src="https://github.com/user-attachments/assets/c2d2194b-318a-436c-b1d6-3e5db372df9f" />

