### PR TITLE
DPT-2195 Stop missing data from tripping DLQ alarms

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1063,6 +1063,7 @@ Resources:
       DatapointsToAlarm: 1
       MetricName: ApproximateNumberOfMessagesVisible
       Namespace: AWS/SQS
+      TreatMissingData: notBreaching
       AlarmActions:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       OKActions:


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-2195

## :bulb: Description

Stops an alarm from sending prod alert messages when transitioning from `missingData` to `OK`

## :test_tube: Testing Instructions/Notes

Only way to test this is to monitor the `audit-audit-message-delivery-stream-DLQ` alarm and the associated Queue `audit-[ENV]-audit-message-delivery-stream-dlq` as it takes time for the queue to switch to inactive and is not predictable (unless you delete the queue).


