### PR TITLE
DPT-2679: Remove long-term retention and backup from unencrypted message-batch bucket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/template.yaml
+++ b/template.yaml
@@ -204,27 +204,11 @@ Resources:
         LogFilePrefix: !Sub ${AWS::StackName}-${Environment}-message-batch/
       LifecycleConfiguration:
         Rules:
-          - Id: AuditGlacierRule
+          - Id: ExpireObjectsAfter90Days
             Status: Enabled
-            Transitions:
-              - TransitionInDays: 90
-                StorageClass: GLACIER_IR
-          - !If
-            - IsProduction
-            - Id: ProductionExpirationRule
-              Status: Enabled
-              ExpirationInDays: 2557
-              NoncurrentVersionExpiration:
-                NoncurrentDays: 31
-            - !Ref AWS::NoValue
-          - !If
-            - IsTestableEnv
-            - Id: NonProductionExpirationRule
-              Status: Enabled
-              ExpirationInDays: 120
-              NoncurrentVersionExpiration:
-                NoncurrentDays: 31
-            - !Ref AWS::NoValue
+            ExpirationInDays: 90
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 7
           - Id: DeleteExpiredObjectMarkers
             Status: Enabled
             ExpiredObjectDeleteMarker: true
@@ -251,9 +235,6 @@ Resources:
         - Id: EntireBucket
         - Id: Failures
           Prefix: failures/
-      Tags:
-        - Key: BackupFrequency
-          Value: Bihourly
 
   MessageBatchBucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-2679
- **Semantic Version**: <!-- Add [major], [minor], or [patch] to your commit message title. Default is [patch] if omitted. -->
  - `[patch]` — bug fix or small change (default)

## :bulb: Description

The `audit-message-batch` S3 bucket is a temporary staging area for storage. Objects should not persist beyond 90 days.

## :sparkles: Changes Made

- Replace Glacier transition and environment-conditional expiration rules with a single 90-day expiration lifecycle rule
- Remove non current version retention from 31 days to 7 days (temporary data)
- Remove BackupFrequency tag so the bucket is no longer picked up by Backup as a Service
