### PR TITLE
DPT-3047: Fix SonarQube report not being generated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,11 @@ sonar.projectKey=txma-audit
 sonar.projectName=txma-audit
 sonar.projectVersion=1.0
 
-sonar.sources=src
+sonar.sources=src,common
+sonar.tests=src,common
+sonar.test.inclusions=**/*.test.ts
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/**/*.test.ts
+sonar.exclusions=**/*.test.ts
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,25 +1,5 @@
 import { defineConfig } from 'vitest/config'
 
-const baseCoverage = [
-  // scan all files
-  '<rootDir>/**/*.ts',
-  // scripts can be ignored
-  '!**/scripts/**',
-  // types can be ignored
-  '!**/interface/**',
-  '!**/interfaces/**',
-  '!**/type/**',
-  '!**/types/**',
-  // The buildLogger function doesn't have anything we can meaningfully test
-  '!**/logger.ts',
-  // ignoring the tests folder
-  '!**/tests/**',
-  // ignore config files
-  '!**/*.config.ts',
-  // ignore .files
-  '!**/.*'
-]
-
 export default defineConfig({
   test: {
     globals: true,
@@ -38,7 +18,21 @@ export default defineConfig({
     setupFiles: ['./common/utils/tests/setup/testEnvVars.ts'],
     coverage: {
       provider: 'v8',
-      exclude: ['/node_modules/', '/.yarn/', '/dist/'].concat(baseCoverage)
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.ts', 'common/**/*.ts'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/scripts/**',
+        '**/interface/**',
+        '**/interfaces/**',
+        '**/type/**',
+        '**/types/**',
+        '**/logger.ts',
+        '**/tests/**',
+        '**/*.config.ts',
+        '**/*.test.ts'
+      ]
     }
   }
 })


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-3047
- **Semantic Version**: <!-- Add [major], [minor], or [patch] to your commit message title. Default is [patch] if omitted. -->
  - `[patch]` — bug fix or small change (default)


## :bulb: Description

SonarQube reports were not being generated because some Jest configs were still in place. The fix resolves this issue

## :sparkles: Changes Made

  vitest.config.ts — Removed the baseCoverage array and replaced it with:
  
  - reporter: ['text', 'lcov'] — generates the lcov.info file
  - coverage.include: ['src/**/*.ts', 'common/**/*.ts'] — explicitly includes both source directories
  - coverage.exclude — plain glob patterns (no ! prefix, no <rootDir>)
  
  sonar-project.properties — Added:
  
  - sonar.sources=src,common
  - sonar.tests=src,common
  - sonar.test.inclusions=**/*.test.ts
  - Broadened exclusions to **/*.test.ts

## :test_tube: Testing Instructions/Notes

  `npm run test:cov` produces a valid 777-line coverage/lcov.info at the path SonarCloud is configured
  to read `(sonar.javascript.lcov.reportPaths=./coverage/lcov.info)`.

## :framed_picture: Screenshots (if applicable)

<img width="850" height="762" alt="Screenshot 2026-06-29 at 15 32 21" src="https://github.com/user-attachments/assets/b123fe4e-44e4-4005-8208-3b40ee3e0de0" />

