### PR TITLE
DPT-2839: [patch] re-enable test roles and encryption decryption test to check permission failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/template.yaml
+++ b/template.yaml
@@ -1835,6 +1835,33 @@ Resources:
       FunctionName: !Ref S3KeyRotationFunction
       Principal: !Ref TestRoleArn
 
+  TestRoleKmsAccessPolicy:
+    Condition: TestRoleResources
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-test-role-kms-access
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowGeneratorKeyAccess
+            Effect: Allow
+            Action:
+              - kms:DescribeKey
+              - kms:GenerateDataKey*
+              - kms:Encrypt
+              - kms:Decrypt
+            Resource: '{{resolve:ssm:S3EncryptionGeneratorKmsKeyArn}}'
+          - Sid: AllowBackupKeyAccess
+            Effect: Allow
+            Action:
+              - kms:DescribeKey
+              - kms:GenerateDataKey*
+              - kms:Encrypt
+              - kms:Decrypt
+            Resource: '{{resolve:ssm:S3EncryptionGeneratorKmsKeyArnBck}}'
+      Roles:
+        - !Select [1, !Split ['/', !Select [5, !Split [':', !Ref TestRoleArn]]]]
+
   ##############################
   # End: Development resources #
   ##############################

--- a/tests/integrationTests/testSuites/s3KeyRotationMigration.spec.ts
+++ b/tests/integrationTests/testSuites/s3KeyRotationMigration.spec.ts
@@ -145,7 +145,7 @@ const createS3BatchEvent = (
   }))
 })
 
-describe.todo('S3 Key Rotation Migration - Integration Tests', () => {
+describe('S3 Key Rotation Migration - Integration Tests', () => {
   let bucketName: string
   let bucketArn: string
   let functionName: string


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-DPT-2839

## :bulb: Description

Re-enabling the tests to check where the permission failures where happening


## :framed_picture: Screenshots (if applicable)

<img width="925" height="338" alt="Screenshot 2026-07-06 at 16 03 25" src="https://github.com/user-attachments/assets/e7b04831-80a9-40f2-87de-eaae77d068d7" />

