### PR TITLE
DPT-2839: amend type of policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/template.yaml
+++ b/template.yaml
@@ -1837,9 +1837,9 @@ Resources:
 
   TestRoleKmsAccessPolicy:
     Condition: TestRoleResources
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: !Sub ${AWS::StackName}-test-role-kms-access
+      ManagedPolicyName: !Sub ${AWS::StackName}-test-role-kms-access
       PolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-2839

## :bulb: Description

Changed the resource type from `AWS::IAM::Policy` to `AWS::IAM::ManagedPolicy` in
  `template.yaml`. A managed policy uses iam:CreatePolicy + iam:AttachRolePolicy instead,
  which the deploy role already has (since other AWS::IAM::ManagedPolicy resources in the
  template deploy successfully).

I have a ready fallback using `AWS::KMS::Grant` which avoids touching the role entirely if this doesn't work.
