### PR TITLE
DPT-3086: boost SonarQube test coverage

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate coverage report
         run: npm run test:cov
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/common/sharedServices/kms/createKmsClientProvider.test.ts
+++ b/common/sharedServices/kms/createKmsClientProvider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createKmsClientProvider } from './createKmsClientProvider'
+
+const mockGetClient = vi.fn()
+const mockLimitRegions = vi.fn()
+
+vi.mock('@aws-crypto/kms-keyring-node', () => ({
+  getClient: (...args: unknown[]) => mockGetClient(...args) as unknown,
+  limitRegions: (...args: unknown[]) => mockLimitRegions(...args) as unknown,
+  KMS: 'MOCK_KMS_CONSTRUCTOR'
+}))
+
+vi.mock('../../utils/helpers/getEnv', () => ({
+  getEnv: vi.fn(() => 'eu-west-2')
+}))
+
+describe('createKmsClientProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a region-limited KMS client provider using the configured AWS_REGION', () => {
+    // Unit Test
+    const mockBaseProvider = vi.fn()
+    const mockLimitedProvider = vi.fn()
+    mockGetClient.mockReturnValue(mockBaseProvider)
+    mockLimitRegions.mockReturnValue(mockLimitedProvider)
+
+    const result = createKmsClientProvider()
+
+    expect(mockGetClient).toHaveBeenCalledWith('MOCK_KMS_CONSTRUCTOR', {
+      region: 'eu-west-2'
+    })
+    expect(mockLimitRegions).toHaveBeenCalledWith(
+      ['eu-west-2'],
+      mockBaseProvider
+    )
+    expect(result).toBe(mockLimitedProvider)
+  })
+})

--- a/common/sharedServices/s3/getS3ObjectAsStream.test.ts
+++ b/common/sharedServices/s3/getS3ObjectAsStream.test.ts
@@ -42,4 +42,15 @@ describe('getS3Object -', () => {
     expect(calls[0].args[0].input).toEqual(getObjectCommandInput)
     expect(returnedData).toEqual(testDataStream)
   })
+
+  it('throws an error when Body is not a Readable stream', async () => {
+    // Unit Test
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: undefined
+    })
+
+    await expect(
+      getS3ObjectAsStream(TEST_TEMPORARY_BUCKET_NAME, TEST_S3_OBJECT_KEY)
+    ).rejects.toThrow('Get S3 Object command did not return stream')
+  })
 })

--- a/common/utils/awsSdkClients.test.ts
+++ b/common/utils/awsSdkClients.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('awsSdkClients', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    process.env.AWS_REGION = 'eu-west-2'
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('exports raw clients when XRAY_ENABLED is not set', async () => {
+    // Unit Test
+    delete process.env.XRAY_ENABLED
+
+    const { firehoseClient, s3Client } = await import('./awsSdkClients')
+
+    expect(firehoseClient).toBeDefined()
+    expect(s3Client).toBeDefined()
+  })
+
+  it('exports raw clients when XRAY_ENABLED is false', async () => {
+    // Unit Test
+    process.env.XRAY_ENABLED = 'false'
+
+    const { firehoseClient, s3Client } = await import('./awsSdkClients')
+
+    expect(firehoseClient).toBeDefined()
+    expect(s3Client).toBeDefined()
+  })
+
+  it('wraps clients with X-Ray when XRAY_ENABLED is true', async () => {
+    // Unit Test
+    process.env.XRAY_ENABLED = 'true'
+
+    const { firehoseClient, s3Client } = await import('./awsSdkClients')
+
+    expect(firehoseClient).toBeDefined()
+    expect(s3Client).toBeDefined()
+  })
+
+  it('exports s3ControlClient and secretsManagerClient', async () => {
+    // Unit Test
+    const { s3ControlClient, secretsManagerClient } =
+      await import('./awsSdkClients')
+
+    expect(s3ControlClient).toBeDefined()
+    expect(secretsManagerClient).toBeDefined()
+  })
+})

--- a/common/utils/helpers/firehose/auditEventsToFirehoseRecords.test.ts
+++ b/common/utils/helpers/firehose/auditEventsToFirehoseRecords.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { AuditEvent } from '../../../../common/types/auditEvent'
+import { auditEventsToFirehoseRecords } from './auditEventsToFirehoseRecords'
+
+describe('auditEventsToFirehoseRecords', () => {
+  it('converts audit events to firehose records with JSON-serialized data', () => {
+    // Unit Test
+    const events: AuditEvent[] = [
+      { event_name: 'AUTH_EVENT', timestamp: 1234567890, event_id: 'id-1' },
+      { event_name: 'FRAUD_EVENT', timestamp: 1234567891, event_id: 'id-2' }
+    ]
+
+    const result = auditEventsToFirehoseRecords(events)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].Data).toEqual(Buffer.from(JSON.stringify(events[0])))
+    expect(result[1].Data).toEqual(Buffer.from(JSON.stringify(events[1])))
+  })
+
+  it('returns an empty array when given no events', () => {
+    // Unit Test
+    const result = auditEventsToFirehoseRecords([])
+
+    expect(result).toEqual([])
+  })
+})

--- a/common/utils/helpers/readableToString.test.ts
+++ b/common/utils/helpers/readableToString.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { Readable } from 'stream'
+import { readableToString } from './readableToString'
+
+describe('readableToString', () => {
+  it('converts a readable stream to a UTF-8 string', async () => {
+    // Unit Test
+    const testData = 'hello world'
+    const readable = new Readable()
+    readable.push(testData)
+    readable.push(null)
+
+    const result = await readableToString(readable)
+
+    expect(result).toBe(testData)
+  })
+
+  it('handles multi-chunk streams', async () => {
+    // Unit Test
+    const readable = new Readable()
+    readable.push('chunk1')
+    readable.push('chunk2')
+    readable.push('chunk3')
+    readable.push(null)
+
+    const result = await readableToString(readable)
+
+    expect(result).toBe('chunk1chunk2chunk3')
+  })
+
+  it('handles an empty stream', async () => {
+    // Unit Test
+    const readable = new Readable()
+    readable.push(null)
+
+    const result = await readableToString(readable)
+
+    expect(result).toBe('')
+  })
+})

--- a/common/utils/helpers/tryParseJson.test.ts
+++ b/common/utils/helpers/tryParseJson.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { tryParseJSON } from './tryParseJson'
+
+vi.mock('../../../common/sharedServices/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+describe('tryParseJSON', () => {
+  it('parses valid JSON and returns the parsed object', () => {
+    // Unit Test
+    const input = JSON.stringify({ event_name: 'test', timestamp: 123 })
+
+    const result = tryParseJSON(input)
+
+    expect(result).toEqual({ event_name: 'test', timestamp: 123 })
+  })
+
+  it('returns an empty object when given invalid JSON', () => {
+    // Unit Test
+    const result = tryParseJSON('not valid json {{{')
+
+    expect(result).toEqual({})
+  })
+
+  it('returns an empty object when given an empty string', () => {
+    // Unit Test
+    const result = tryParseJSON('')
+
+    expect(result).toEqual({})
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/src/lambdas/auditMessageFirehoseReingest/deleteOrUpdateS3Objects.test.ts
+++ b/src/lambdas/auditMessageFirehoseReingest/deleteOrUpdateS3Objects.test.ts
@@ -4,6 +4,15 @@ import { putS3Object } from '../../../common/sharedServices/s3/putS3Object'
 import { S3ObjectDetails } from '../../../common/types/s3ObjectDetails'
 import { deleteOrUpdateS3Objects } from './deleteOrUpdateS3Objects'
 
+vi.mock('../../../common/sharedServices/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
 vi.mock('../../../common/sharedServices/s3/deleteS3Object', () => ({
   deleteS3Object: vi.fn()
 }))
@@ -93,5 +102,53 @@ describe('deleteOrUpdateS3Objects', () => {
       expect.any(Buffer)
     )
     expect(deleteS3Object).not.toHaveBeenCalled()
+  })
+
+  it('should handle errors when deleting s3 objects', async () => {
+    // Unit Test
+    vi.mocked(deleteS3Object).mockRejectedValue(new Error('Delete failed'))
+
+    const results: S3ObjectDetails[] = [
+      {
+        auditEventsFailedReingest: [],
+        auditEvents: [],
+        bucket,
+        key: 'mockKey1',
+        sqsRecordMessageId: 'mockMessageId1'
+      }
+    ]
+
+    await expect(deleteOrUpdateS3Objects(results)).resolves.not.toThrow()
+
+    expect(deleteS3Object).toHaveBeenCalledWith(bucket, 'mockKey1')
+  })
+
+  it('should handle errors when updating s3 objects', async () => {
+    // Unit Test
+    vi.mocked(putS3Object).mockRejectedValue(new Error('Put failed'))
+
+    const results: S3ObjectDetails[] = [
+      {
+        auditEvents: [],
+        auditEventsFailedReingest: [
+          {
+            event_id: 'mockEventId1',
+            event_name: 'mockEventName1',
+            timestamp: 12345678
+          }
+        ],
+        bucket,
+        key: 'mockKey1',
+        sqsRecordMessageId: 'mockMessageId1'
+      }
+    ]
+
+    await expect(deleteOrUpdateS3Objects(results)).resolves.not.toThrow()
+
+    expect(putS3Object).toHaveBeenCalledWith(
+      bucket,
+      'mockKey1',
+      expect.any(Buffer)
+    )
   })
 })

--- a/src/lambdas/s3CopyAndEncrypt/handler.test.ts
+++ b/src/lambdas/s3CopyAndEncrypt/handler.test.ts
@@ -38,4 +38,91 @@ describe('InitiateCopyAndEncrypt', function () {
     )
     expect(encryptAuditData).not.toHaveBeenCalled()
   })
+
+  it('throws an error when event has no s3 data in Records', async () => {
+    // Unit Test
+    const eventWithNoS3 = {
+      Records: [
+        {
+          messageId: '',
+          receiptHandle: '',
+          body: JSON.stringify({ Records: [{ eventSource: 'aws:s3' }] }),
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: '',
+            SenderId: '',
+            ApproximateFirstReceiveTimestamp: ''
+          },
+          messageAttributes: {},
+          md5OfBody: '',
+          eventSource: '',
+          eventSourceARN: '',
+          awsRegion: ''
+        }
+      ]
+    }
+
+    await expect(handler(eventWithNoS3, mockLambdaContext)).rejects.toThrow(
+      'No s3 data in event'
+    )
+    expect(encryptAuditData).not.toHaveBeenCalled()
+  })
+
+  it('defaults to empty string when bucket name is missing', async () => {
+    // Unit Test
+    const eventWithNoName = {
+      Records: [
+        {
+          messageId: '',
+          receiptHandle: '',
+          body: JSON.stringify({
+            Records: [{ s3: { bucket: {}, object: { key: 'someKey' } } }]
+          }),
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: '',
+            SenderId: '',
+            ApproximateFirstReceiveTimestamp: ''
+          },
+          messageAttributes: {},
+          md5OfBody: '',
+          eventSource: '',
+          eventSourceARN: '',
+          awsRegion: ''
+        }
+      ]
+    }
+
+    await handler(eventWithNoName, mockLambdaContext)
+    expect(encryptAuditData).toHaveBeenCalledWith('', 'someKey')
+  })
+
+  it('defaults to empty string when object key is missing', async () => {
+    // Unit Test
+    const eventWithNoKey = {
+      Records: [
+        {
+          messageId: '',
+          receiptHandle: '',
+          body: JSON.stringify({
+            Records: [{ s3: { bucket: { name: 'myBucket' }, object: {} } }]
+          }),
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: '',
+            SenderId: '',
+            ApproximateFirstReceiveTimestamp: ''
+          },
+          messageAttributes: {},
+          md5OfBody: '',
+          eventSource: '',
+          eventSourceARN: '',
+          awsRegion: ''
+        }
+      ]
+    }
+
+    await handler(eventWithNoKey, mockLambdaContext)
+    expect(encryptAuditData).toHaveBeenCalledWith('myBucket', '')
+  })
 })

--- a/src/lambdas/s3KeyRotationMigration/handler.test.ts
+++ b/src/lambdas/s3KeyRotationMigration/handler.test.ts
@@ -161,6 +161,21 @@ describe('S3 Key Rotation Handler', () => {
     expect(mockReEncryptObjectWithDualKeys).not.toHaveBeenCalled()
   })
 
+  it('handles non-Error rejection reasons with Unknown error message', async () => {
+    // Unit Test
+    const event = createS3BatchEvent(1, 'audit-bucket')
+
+    mockReEncryptObjectWithDualKeys.mockRejectedValueOnce('string error reason')
+
+    const result = await handler(event, mockContext)
+
+    expect(result.results[0]).toEqual({
+      taskId: 'task-0',
+      resultCode: 'PermanentFailure',
+      resultString: 'Failed: Unknown error'
+    })
+  })
+
   it('includes invocation details in response', async () => {
     // Unit Test
     const event = createS3BatchEvent(1)

--- a/src/lambdas/s3KeyRotationMigration/reEncryptObjectWithDualKeys.test.ts
+++ b/src/lambdas/s3KeyRotationMigration/reEncryptObjectWithDualKeys.test.ts
@@ -64,7 +64,12 @@ describe('reEncryptObjectWithDualKeys', () => {
     process.env.BACKUP_KEY_ID = TEST_BACKUP_KEY
 
     // KmsKeyringNode is mocked to just return the config object for testing
-    mockKmsKeyringNode.mockImplementation(<T>(config: T): T => config)
+    mockKmsKeyringNode.mockImplementation(function (
+      this: Record<string, unknown>,
+      config: Record<string, unknown>
+    ) {
+      Object.assign(this, config)
+    })
 
     mockDecrypt = vi.fn()
     mockEncrypt = vi.fn()

--- a/src/lambdas/s3KeyRotationMigration/reEncryptObjectWithDualKeys.test.ts
+++ b/src/lambdas/s3KeyRotationMigration/reEncryptObjectWithDualKeys.test.ts
@@ -65,10 +65,10 @@ describe('reEncryptObjectWithDualKeys', () => {
 
     // KmsKeyringNode is mocked to just return the config object for testing
     mockKmsKeyringNode.mockImplementation(function (
-      this: Record<string, unknown>,
-      config: Record<string, unknown>
+      this: KmsKeyringNode,
+      config?: Partial<Record<string, unknown>>
     ) {
-      Object.assign(this, config)
+      if (config) Object.assign(this, config)
     })
 
     mockDecrypt = vi.fn()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,8 +11,11 @@ export default defineConfig({
       '**/sharedServices/firehose/*.test.ts',
       '**/sharedServices/kms/*.test.ts',
       '**/s3CopyAndEncrypt/*.test.ts',
+      '**/s3KeyRotationMigration/*.test.ts',
       '**/redriveSnsDlqEvents/*.test.ts',
-      '**/auditMessageFirehoseReingest/*.test.ts'
+      '**/auditMessageFirehoseReingest/*.test.ts',
+      '**/utils/helpers/**/*.test.ts',
+      '**/utils/awsSdkClients.test.ts'
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     setupFiles: ['./common/utils/tests/setup/testEnvVars.ts'],


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-3086


## :bulb: Description

Improve unit test coverage from 52% to ~100%
SonarQube was flagging test coverage at 52%, well below the 80% quality gate threshold.

## :sparkles: Changes Made

  New test files:
  
  - common/sharedServices/kms/createKmsClientProvider.test.ts
  - common/utils/helpers/readableToString.test.ts
  - common/utils/helpers/firehose/auditEventsToFirehoseRecords.test.ts
  - common/utils/helpers/tryParseJson.test.ts
  - common/utils/awsSdkClients.test.ts
  
  Updated test files (additional test cases):
  
  - common/sharedServices/s3/getS3ObjectAsStream.test.ts — null/undefined body branch
  - src/lambdas/auditMessageFirehoseReingest/deleteOrUpdateS3Objects.test.ts — error handling
  in delete/update paths
  - src/lambdas/s3CopyAndEncrypt/handler.test.ts — missing bucket name, missing object key, and
  missing s3 data branches
  - src/lambdas/s3KeyRotationMigration/handler.test.ts — non-Error rejection reason branch
  - src/lambdas/s3KeyRotationMigration/reEncryptObjectWithDualKeys.test.ts — fixed pre-existing
  bug where KmsKeyringNode mock used an arrow function instead of a function expression (arrow
  functions cannot be used as constructors)
  
  Config:
  
  - vitest.config.ts — added include patterns for utils/helpers, awsSdkClients, and
  s3KeyRotationMigration test files that were previously excluded from test runs

## :framed_picture: Screenshots (if applicable)

<img width="315" height="198" alt="Screenshot 2026-07-27 at 16 49 57" src="https://github.com/user-attachments/assets/d174611d-dfce-4fff-a045-473c0b2ff118" />

## :handshake: Related Pull Requests

https://govukverify.atlassian.net/browse/DPT-2711
