### PR TITLE
DPT-3036: [minor] Run integration tests against feature branches

### DIFF
--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -100,7 +100,7 @@ jobs:
           STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
         run: |
           IMAGE_URI="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          TASK_DEFINITION_FAMILY="${STACK_NAME}-integration-tests"
+          TASK_DEFINITION_FAMILY="${STACK_NAME}-integration-test-runner"
           echo "Updating task definition: $TASK_DEFINITION_FAMILY with image: $IMAGE_URI"
 
           # Get the current task definition

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -96,15 +96,16 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ needs.upload-testing-image.outputs.stack-name }}-integration-test-repository
-          ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
           IMAGE_TAG: ${{ github.sha }}
+          STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
         run: |
           IMAGE_URI="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          echo "Updating task definition with image: $IMAGE_URI"
+          TASK_DEFINITION_FAMILY="${STACK_NAME}-integration-tests"
+          echo "Updating task definition: $TASK_DEFINITION_FAMILY with image: $IMAGE_URI"
 
           # Get the current task definition
           TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition "$ECS_TASK_DEFINITION" \
+            --task-definition "$TASK_DEFINITION_FAMILY" \
             --query 'taskDefinition' \
             --output json)
 

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -135,7 +135,7 @@ jobs:
 
           SUBNET_IDS=$(aws cloudformation describe-stacks \
             --stack-name vpc \
-            --output json | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue')
+            --output json | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "ProtectedSubnetIdA") | .OutputValue')
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -66,7 +66,7 @@ jobs:
           CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
-          IMAGE_TAG: latest
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -f tests/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg GIT_COMMIT=$(git log -1 --format=%h) .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -90,10 +90,13 @@ jobs:
       - name: Run ECS task
         id: run-task
         env:
-          STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
-          TEST_ENVIRONMENT: dev
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
           ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
+          IMAGE_TAG: ${{ github.sha }}
+          STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
+          TEST_ENVIRONMENT: dev
         run: |
           echo "Running integration tests against stack: $STACK_NAME"
           SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
@@ -106,6 +109,7 @@ jobs:
             --overrides '{
               "containerOverrides": [{
                 "name": "integration-tests",
+                "image": "'"$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"'",
                 "environment": [
                   {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
                   {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -127,11 +127,11 @@ jobs:
       - name: Run ECS task
         id: run-task
         env:
-          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
+          ECS_CLUSTER: ${{ needs.upload-testing-image.outputs.stack-name }}-integration-test-runner
           STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
           TEST_ENVIRONMENT: dev
         run: |
-          echo "Running integration tests against stack: $STACK_NAME"
+          echo "Running integration tests against cluster: $ECS_CLUSTER"
 
           SUBNET_IDS=$(aws cloudformation describe-stacks \
             --stack-name vpc \
@@ -144,7 +144,7 @@ jobs:
             --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],assignPublicIp=DISABLED}" \
             --overrides '{
               "containerOverrides": [{
-                "name": "integration-tests",
+                "name": "'"$ECS_CLUSTER"'",
                 "environment": [
                   {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
                   {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -106,6 +106,7 @@ jobs:
           SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
           IMAGE_ANR="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           TASK_WITH_STACK="${ECS_TASK_DEFINITION/STACK_NAME/"$STACK_NAME"}"
+          echo "$TASK_WITH_STACK"
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -94,16 +94,15 @@ jobs:
           TEST_ENVIRONMENT: dev
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
           ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
-          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
-          SECURITY_GROUP_IDS: ${{ secrets.SECURITY_GROUP_IDS }}
         run: |
           echo "Running integration tests against stack: $STACK_NAME"
+          SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
             --task-definition "$ECS_TASK_DEFINITION" \
             --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],securityGroups=[$SECURITY_GROUP_IDS],assignPublicIp=DISABLED}" \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],assignPublicIp=DISABLED}" \
             --overrides '{
               "containerOverrides": [{
                 "name": "integration-tests",

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -1,22 +1,141 @@
 name: 'Run Integration tests'
-description: 'Run the integration tests against a deployed feature branch in the dev account'
 
 on:
+  workflow_dispatch:
+    inputs:
+      stack-name:
+        description: 'Override stack name (leave empty to derive from branch name)'
+        required: false
+        default: ''
   push:
     branches:
-      - feature/*
-  pull_request:
-    types: [opened, synchronize, reopened]
+      - 'feature/**'
+
 env:
-  TEST_ENVIRONMENT: 'build'
-inputs:
-  stack_name:
-    description: 'Name of stack to run the tests against'
-    required: true
-    default: 'audit'
-outputs:
-  test-result: # id of output
-    description: 'A pass or failed indicator'
-runs:
-  using: 'docker'
-  image: 'tests/Dockerfile'
+  AWS_REGION: eu-west-2
+
+jobs:
+  upload-testing-image:
+    name: Upload testing image to ECR
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      stack-name: ${{ steps.derive-stack-name.outputs.stack_name }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Derive stack name from branch
+        id: derive-stack-name
+        # Note: algorithm copied from build-test-package.yaml
+        run: |
+          if [ -n "${{ inputs.stack-name }}" ]; then
+            stack_name="${{ inputs.stack-name }}"
+          else
+            FEATURE_BRANCH_NAME="${{ github.ref_name }}"
+            stack_name=$(
+              echo ${FEATURE_BRANCH_NAME##*/} | \
+              tr -cd '[a-zA-Z0-9-]' | \
+              tr '[:upper:]' '[:lower:]' | \
+              cut -c -32
+            )
+          fi
+          echo "stack_name=${stack_name}" >> "$GITHUB_OUTPUT"
+          echo "Resolved stack name: ${stack_name}"
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.4.0
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -f tests/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg GIT_COMMIT=$(git log -1 --format=%h) .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+  run-integration-tests:
+    name: Run integration tests via ECS
+    needs: upload-testing-image
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
+
+      - name: Run ECS task
+        id: run-task
+        env:
+          STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
+          TEST_ENVIRONMENT: dev
+          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
+          ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
+          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
+          SECURITY_GROUP_IDS: ${{ secrets.SECURITY_GROUP_IDS }}
+        run: |
+          echo "Running integration tests against stack: $STACK_NAME"
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$ECS_CLUSTER" \
+            --task-definition "$ECS_TASK_DEFINITION" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],securityGroups=[$SECURITY_GROUP_IDS],assignPublicIp=DISABLED}" \
+            --overrides '{
+              "containerOverrides": [{
+                "name": "integration-tests",
+                "environment": [
+                  {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
+                  {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}
+                ]
+              }]
+            }' \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          echo "Task started: $TASK_ARN"
+          echo "TASK_ARN=$TASK_ARN" >> "$GITHUB_ENV"
+
+      - name: Wait for ECS task to complete
+        env:
+          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
+        run: |
+          echo "Waiting for task to finish..."
+          aws ecs wait tasks-stopped \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+
+          echo "Task exit code: $EXIT_CODE"
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Integration tests failed with exit code $EXIT_CODE"
+            exit 1
+          fi

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -100,6 +100,8 @@ jobs:
         run: |
           echo "Running integration tests against stack: $STACK_NAME"
           SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
+          IMAGE_ANR="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "$IMAGE_ANR"
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
@@ -109,7 +111,7 @@ jobs:
             --overrides '{
               "containerOverrides": [{
                 "name": "integration-tests",
-                "image": "'"$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"'",
+                "image": "'"$IMAGE_ANR"'",
                 "environment": [
                   {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
                   {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 15
     outputs:
       stack-name: ${{ steps.derive-stack-name.outputs.stack_name }}
+      registry: ${{ steps.login-ecr.outputs.registry }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -7,7 +7,10 @@ on:
         description: 'Override stack name (leave empty to derive from branch name)'
         required: false
         default: ''
-  push:
+  workflow_run:
+    workflows: ['Build, Test and Package']
+    types:
+      - completed
     branches:
       - 'feature/**'
 
@@ -17,6 +20,9 @@ env:
 jobs:
   upload-testing-image:
     name: Upload testing image to ECR
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success')
     permissions:
       id-token: write
       contents: read
@@ -35,7 +41,7 @@ jobs:
           if [ -n "${{ inputs.stack-name }}" ]; then
             stack_name="${{ inputs.stack-name }}"
           else
-            FEATURE_BRANCH_NAME="${{ github.ref_name }}"
+            FEATURE_BRANCH_NAME="${{ github.event.workflow_run.head_branch || github.ref_name }}"
             stack_name=$(
               echo ${FEATURE_BRANCH_NAME##*/} | \
               tr -cd '[a-zA-Z0-9-]' | \

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -91,26 +91,54 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
+      - name: Register new task definition revision with image
+        id: register-task-def
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ needs.upload-testing-image.outputs.stack-name }}-integration-test-repository
+          ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_URI="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "Updating task definition with image: $IMAGE_URI"
+
+          # Get the current task definition
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "$ECS_TASK_DEFINITION" \
+            --query 'taskDefinition' \
+            --output json)
+
+          # Update the image and remove read-only fields
+          NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
+            --arg IMAGE "$IMAGE_URI" \
+            '.containerDefinitions[0].image = $IMAGE |
+             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+
+          # Register the new revision
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$NEW_TASK_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+
+          echo "Registered new task definition: $NEW_TASK_DEF_ARN"
+          echo "TASK_DEF_ARN=$NEW_TASK_DEF_ARN" >> "$GITHUB_ENV"
+
       - name: Run ECS task
         id: run-task
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
-          ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
-          IMAGE_TAG: ${{ github.sha }}
           STACK_NAME: ${{ needs.upload-testing-image.outputs.stack-name }}
           TEST_ENVIRONMENT: dev
         run: |
           echo "Running integration tests against stack: $STACK_NAME"
-          SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
-          IMAGE_ANR="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          TASK_WITH_STACK="${ECS_TASK_DEFINITION/STACK_NAME/"$STACK_NAME"}"
-          echo "$TASK_WITH_STACK"
+
+          SUBNET_IDS=$(aws cloudformation describe-stacks \
+            --stack-name vpc \
+            --output json | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue')
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
-            --task-definition "TASK_WITH_STACK" \
+            --task-definition "$TASK_DEF_ARN" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],assignPublicIp=DISABLED}" \
             --overrides '{

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -13,6 +13,9 @@ on:
       - completed
     branches:
       - 'feature/**'
+  push:
+    branches:
+      - 'feature/**'
 
 env:
   AWS_REGION: eu-west-2

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -24,7 +24,6 @@ jobs:
     timeout-minutes: 15
     outputs:
       stack-name: ${{ steps.derive-stack-name.outputs.stack_name }}
-      registry: ${{ steps.login-ecr.outputs.registry }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -87,6 +86,10 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Run ECS task
         id: run-task

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build, tag, and push testing image to Amazon ECR
         env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
           IMAGE_TAG: latest

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
           IMAGE_TAG: latest
         run: |
           docker build -f tests/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG --build-arg GIT_COMMIT=$(git log -1 --format=%h) .

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -105,11 +105,11 @@ jobs:
           echo "Running integration tests against stack: $STACK_NAME"
           SUBNET_IDS=$(aws cloudformation describe-stacks --stack-name vpc --output json | jq '.Stacks[].Outputs[] | select(.OutputKey == "PrivateSubnetIdA") | .OutputValue' | xargs)
           IMAGE_ANR="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          echo "$IMAGE_ANR"
+          TASK_WITH_STACK="${ECS_TASK_DEFINITION/STACK_NAME/"$STACK_NAME"}"
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "$ECS_CLUSTER" \
-            --task-definition "$ECS_TASK_DEFINITION" \
+            --task-definition "TASK_WITH_STACK" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],assignPublicIp=DISABLED}" \
             --overrides '{

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -1,0 +1,22 @@
+name: 'Run Integration tests'
+description: 'Run the integration tests against a deployed feature branch in the dev account'
+
+on:
+  push:
+    branches:
+      - feature/*
+  pull_request:
+    types: [opened, synchronize, reopened]
+env:
+  TEST_ENVIRONMENT: 'build'
+inputs:
+  stack_name:
+    description: 'Name of stack to run the tests against'
+    required: true
+    default: 'audit'
+outputs:
+  test-result: # id of output
+    description: 'A pass or failed indicator'
+runs:
+  using: 'docker'
+  image: 'tests/Dockerfile'

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -146,6 +146,7 @@ jobs:
               "containerOverrides": [{
                 "name": "'"$ECS_CLUSTER"'",
                 "environment": [
+                  {"name": "AWS_REGION", "value": "eu-west-2"},
                   {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
                   {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}
                 ]

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -7,12 +7,6 @@ on:
         description: 'Override stack name (leave empty to derive from branch name)'
         required: false
         default: ''
-  workflow_run:
-    workflows: ['Build, Test and Package']
-    types:
-      - completed
-    branches:
-      - 'feature/**'
   push:
     branches:
       - 'feature/**'
@@ -23,9 +17,6 @@ env:
 jobs:
   upload-testing-image:
     name: Upload testing image to ECR
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success')
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -115,7 +115,6 @@ jobs:
             --overrides '{
               "containerOverrides": [{
                 "name": "integration-tests",
-                "image": "'"$IMAGE_ANR"'",
                 "environment": [
                   {"name": "STACK_NAME", "value": "'"$STACK_NAME"'"},
                   {"name": "TEST_ENVIRONMENT", "value": "'"$TEST_ENVIRONMENT"'"}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Wait for ECS task to complete
         env:
-          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER_NAME }}
+          ECS_CLUSTER: ${{ needs.upload-testing-image.outputs.stack-name }}-integration-test-runner
         run: |
           echo "Waiting for task to finish..."
           aws ecs wait tasks-stopped \

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -7,7 +7,10 @@ on:
         description: 'Override stack name (leave empty to derive from branch name)'
         required: false
         default: ''
-  push:
+  workflow_run:
+    workflows: ['Build, Test and Package']
+    types:
+      - completed
     branches:
       - 'feature/**'
 
@@ -17,6 +20,9 @@ env:
 jobs:
   upload-testing-image:
     name: Upload testing image to ECR
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success')
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -56,12 +56,31 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
+      - name: Check if image already exists in ECR
+        id: check-image
+        env:
+          ECR_REPOSITORY: ${{ steps.derive-stack-name.outputs.stack_name }}-integration-test-repository
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          if aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids imageTag="$IMAGE_TAG" \
+            --region ${{ env.AWS_REGION }} > /dev/null 2>&1; then
+            echo "Image $ECR_REPOSITORY:$IMAGE_TAG already exists, skipping build"
+            echo "image_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Image not found, will build and push"
+            echo "image_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Cosign
+        if: steps.check-image.outputs.image_exists == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v2.4.0
 
       - name: Build, tag, and push testing image to Amazon ECR
+        if: steps.check-image.outputs.image_exists == 'false'
         env:
           CONTAINER_SIGN_KMS_KEY: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 
 # Miscellaneous
 .DS_Store
+.venv
 
 # NPM
 node_modules/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,6 @@ git diff --cached --name-only | if grep --quiet template.yaml
 then
   echo "\nRunning Checkov hook...\n"
   checkov -f template.yaml --framework cloudformation --quiet --skip-check CKV_AWS_116
+  echo "Running Sam Linter...\n"
+  sam validate --lint
 fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@
 .nvmrc
 .pnp.*
 .prettierignore
+.venv
 CODEOWNERS
 coverage/
 dist/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [
   {
     ignores: [
       '.aws-sam',
+      '.venv',
       'coverage',
       'dist/',
       '/tests/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "txma-audit",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "txma-audit",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsc --noEmit && tsx ./esbuild.config.ts",
     "deploy:dev": "npm run build && sam deploy --resolve-s3",
     "lint": "prettier . --check || exit 1 ; eslint . --max-warnings=0",
+    "lint:sam": "sam validate --lint",
     "lint:fix": "prettier . --write ; eslint . --fix",
     "postinstall": "husky",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "txma-audit",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "description": "TxMA Audit",
   "repository": {

--- a/template.yaml
+++ b/template.yaml
@@ -2160,7 +2160,7 @@ Resources:
     Condition: DevEnvironment
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/ecr-integration-tests
+      AliasName: !Sub alias/${AWS::StackName}-ecr-integration-tests
       TargetKeyId: !Ref EcrEncryptionKey
 
   DevContainerSigningKey:
@@ -2184,7 +2184,7 @@ Resources:
     Condition: DevEnvironment
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/dev-container-signing
+      AliasName: !Sub alias/${AWS::StackName}-dev-container-signing
       TargetKeyId: !Ref DevContainerSigningKey
   ##############################
   # End: Development resources #

--- a/template.yaml
+++ b/template.yaml
@@ -745,6 +745,7 @@ Resources:
               - s3:GetObject
               - s3:GetObjectVersion
               - s3:PutObject
+              - s3:ListBucket
             Resource:
               - !GetAtt PermanentMessageBatchBucket.Arn
               - !Sub ${PermanentMessageBatchBucket.Arn}/*

--- a/template.yaml
+++ b/template.yaml
@@ -1932,7 +1932,7 @@ Resources:
               - Action:
                   - cloudformation:DescribeStacks
                 Resource:
-                  - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/audit/*'
+                  - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
                 Effect: Allow
               - Action:
                   - ssm:GetParameter*

--- a/template.yaml
+++ b/template.yaml
@@ -2121,6 +2121,7 @@ Resources:
           }
 
   EcrEncryptionKey:
+    Condition: DevEnvironment
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for ECR repository encryption
@@ -2136,10 +2137,35 @@ Resources:
             Resource: '*'
 
   EcrEncryptionKeyAlias:
+    Condition: DevEnvironment
     Type: AWS::KMS::Alias
     Properties:
       AliasName: alias/ecr-integration-tests
       TargetKeyId: !Ref EcrEncryptionKey
+
+  DevContainerSigningKey:
+    Condition: DevEnvironment
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Asymmetric key for container image signing (Cosign)
+      KeyUsage: SIGN_VERIFY
+      KeySpec: ECC_NIST_P256
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowRootAccountFullAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: '*'
+
+  ContainerSigningKeyAlias:
+    Condition: DevEnvironment
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/dev-container-signing
+      TargetKeyId: !Ref DevContainerSigningKey
   ##############################
   # End: Development resources #
   ##############################

--- a/template.yaml
+++ b/template.yaml
@@ -1184,6 +1184,9 @@ Resources:
                   ParameterValue: !GetAtt AuditMessageDeliveryStreamRole.Arn
         RoleARN: !GetAtt AuditMessageDeliveryStreamRole.Arn
         S3BackupMode: Disabled
+      Tags:
+        - Key: 'Test'
+          Value: 'true'
 
   AuditMessageDeliveryStreamSubscription:
     Type: AWS::SNS::Subscription

--- a/template.yaml
+++ b/template.yaml
@@ -1899,6 +1899,13 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
 
+  IntegrationTestRunnerLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
+      LogGroupName: !Sub /ecs/${AWS::StackName}-integration-test-runner
+      RetentionInDays: 30
+
   IntegrationTestRunnerTaskRole:
     Condition: DevEnvironment
     Type: AWS::IAM::Role

--- a/template.yaml
+++ b/template.yaml
@@ -1861,6 +1861,224 @@ Resources:
               - kms:Decrypt
             Resource: '{{resolve:ssm:S3EncryptionGeneratorKmsKeyArnBck}}'
 
+  IntegrationTestRunnerFargateCluster:
+    Condition: DevEnvironment
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub '${AWS::StackName}-integration-test-runner'
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+  IntegrationTestRunnerTaskDefinition:
+    Condition: DevEnvironment
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Name: !Sub '${AWS::StackName}-integration-test-runner'
+          Image: CONTAINER-IMAGE-PLACEHOLDER
+          Essential: true
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Sub '/ecs/${AWS::StackName}-integration-test-runner'
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-create-group: 'true'
+              awslogs-stream-prefix: 'ecs'
+          Environment:
+            - Name: AWS_REGION
+              Value: !Sub '${AWS::Region}'
+            - Name: $TEST_ENVIRONMENT
+              Value: 'dev'
+      Cpu: 1024
+      Memory: 2048
+      TaskRoleArn: !GetAtt IntegrationTestRunnerTaskRole.Arn
+      ExecutionRoleArn: !GetAtt IntegrationTestRunnerTaskExecutionRole.Arn
+      Family: !Sub '${AWS::StackName}-integration-test-runner'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+  IntegrationTestRunnerTaskRole:
+    Condition: DevEnvironment
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-integration-test-runner-task-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+      Policies:
+        # Copied from PL-*-build-pipeline-TestRole defined in secure pipelines.
+        # The point is that if a change is needed here to run the integration tests then a request needs to be made to
+        # the Platform team to add the same changes to the pipeline's TestRole
+        - PolicyName: IntegrationTestRunner
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - cloudformation:DescribeStacks
+                Resource:
+                  - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/audit/*'
+                Effect: Allow
+              - Action:
+                  - ssm:GetParameter*
+                Resource:
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/tests/*'
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/acceptance-tests/*'
+                Effect: Allow
+              - Action:
+                  - secretsmanager:CancelRotateSecret
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:RotateSecret
+                  - secretsmanager:TagResource
+                  - secretsmanager:UntagResource
+                Resource:
+                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
+                Effect: Allow
+              - Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:PutItem
+                  - dynamodb:Query
+                  - dynamodb:DeleteItem
+                Resource:
+                  - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:*'
+                Effect: Allow
+              - Action: execute-api:Invoke
+                Resource: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*'
+                Effect: Allow
+              - Action: apigateway:GET
+                Resource:
+                  - arn:aws:apigateway:eu-west-2::/apikeys
+                  - arn:aws:apigateway:eu-west-2::/apikeys/*
+                Effect: Allow
+              - Action:
+                  - kms:DescribeKey
+                  - kms:GetPublicKey
+                  - kms:Decrypt
+                  - kms:Verify
+                  - kms:GenerateDataKey
+                Resource:
+                  - arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe
+                Effect: Allow
+                Sid: CustomKMSKeySigning
+              - Action:
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                  - logs:DescribeMetricFilters
+                  - logs:FilterLogEvents
+                  - logs:GetLogEvents
+                  - logs:StartQuery
+                Resource:
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
+                Effect: Allow
+              - Action:
+                  - logs:DescribeQueries
+                  - logs:DescribeQueryDefinitions
+                  - logs:GetLogDelivery
+                  - logs:GetLogRecord
+                  - logs:GetQueryResults
+                  - logs:ListLogDeliveries
+                  - logs:StopQuery
+                  - logs:TestMetricFilter
+                Resource:
+                  - '*'
+                Effect: Allow
+              - Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource:
+                  - arn:aws:s3:::audit-build-pipeline-githubartifactsourcebucket-1xzsrxnqe241c
+                  - arn:aws:s3:::audit-build-pipeline-githubartifactsourcebucket-1xzsrxnqe241c/*
+                Effect: Allow
+                Sid: AccessSourceArtifacts
+              - Action:
+                  - sns:Publish
+                Resource:
+                  - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*'
+                Effect: Allow
+              - Action:
+                  - sqs:SendMessage
+                  - sqs:PurgeQueue
+                  - sqs:ReceiveMessage
+                Resource:
+                  - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*'
+                Effect: Allow
+              - Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetObjectTagging
+                  - s3:ListBucket
+                Resource:
+                  - arn:aws:s3:::template-storage-templatebucket-1upzyw6v9cs42
+                  - arn:aws:s3:::template-storage-templatebucket-1upzyw6v9cs42/*
+                Effect: Allow
+                Sid: TemplateBucketAccess
+              - Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:ListSecrets
+                Resource:
+                  - arn:aws:secretsmanager:eu-west-2:216552277552:secret:*
+                Effect: Allow
+                Sid: ObservabilitySecretsManager
+              - Action:
+                  - kms:DescribeKey
+                  - kms:GetPublicKey
+                  - kms:Decrypt
+                  - kms:Verify
+                Resource:
+                  - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'
+                Effect: Allow
+                Sid: ObservabilityKMS
+              - Action:
+                  - acm-pca:DescribeCertificateAuthority
+                  - acm-pca:GetCertificateAuthorityCertificate
+                  - acm-pca:IssueCertificate
+                  - acm-pca:GetCertificate
+                  - acm-pca:RevokeCertificate
+                Resource:
+                  - !Sub 'arn:aws:acm-pca:${AWS::Region}:${AWS::AccountId}:certificate-authority/*'
+                Effect: Allow
+                Sid: ManageCertificateAuthority
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+  IntegrationTestRunnerTaskExecutionRole:
+    Condition: DevEnvironment
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-integration-test-runner-task-execution-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+      Policies:
+        - PolicyName: CreateLogGroup
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*'
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+
   ##############################
   # End: Development resources #
   ##############################

--- a/template.yaml
+++ b/template.yaml
@@ -1184,9 +1184,6 @@ Resources:
                   ParameterValue: !GetAtt AuditMessageDeliveryStreamRole.Arn
         RoleARN: !GetAtt AuditMessageDeliveryStreamRole.Arn
         S3BackupMode: Disabled
-      Tags:
-        - Key: 'Test'
-          Value: 'true'
 
   AuditMessageDeliveryStreamSubscription:
     Type: AWS::SNS::Subscription

--- a/template.yaml
+++ b/template.yaml
@@ -1973,7 +1973,7 @@ Resources:
                   - kms:Verify
                   - kms:GenerateDataKey
                 Resource:
-                  - arn:aws:kms:eu-west-2:216552277552:key/4bc58ab5-c9bb-4702-a2c3-5d339604a8fe
+                  - arn:aws:kms:eu-west-2:216552277552:key/*
                 Effect: Allow
                 Sid: CustomKMSKeySigning
               - Action:

--- a/template.yaml
+++ b/template.yaml
@@ -1376,7 +1376,13 @@ Resources:
           - Effect: Allow
             Action:
               - kms:Decrypt
-              - kms:GenerateDataKey
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource:
+              - '{{resolve:ssm:FirehoseKmsKeyArn}}'
+          - Effect: Allow
+            Action:
               - kms:CreateGrant
             Resource:
               - '{{resolve:ssm:FirehoseKmsKeyArn}}'

--- a/template.yaml
+++ b/template.yaml
@@ -1373,16 +1373,6 @@ Resources:
               - logs:CreateLogStream
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
-          - Effect: Allow
-            Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey
-              - kms:CreateGrant
-            Resource:
-              - '{{resolve:ssm:FirehoseKmsKeyArn}}'
-            Condition:
-              Bool:
-                kms:GrantIsForAWSResource: true
 
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role

--- a/template.yaml
+++ b/template.yaml
@@ -2040,6 +2040,7 @@ Resources:
                   - kms:DescribeKey
                   - kms:GetPublicKey
                   - kms:Decrypt
+                  - kms:GenerateDataKey
                   - kms:Verify
                 Resource:
                   - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'
@@ -2055,6 +2056,17 @@ Resources:
                   - !Sub 'arn:aws:acm-pca:${AWS::Region}:${AWS::AccountId}:certificate-authority/*'
                 Effect: Allow
                 Sid: ManageCertificateAuthority
+              - Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                  - s3:ListBucket
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-*'
+                  - !Sub 'arn:aws:s3:::${AWS::StackName}-*/*'
+                Effect: Allow
+                Sid: IntegrationTestS3Access
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/template.yaml
+++ b/template.yaml
@@ -1869,6 +1869,7 @@ Resources:
       ClusterSettings:
         - Name: containerInsights
           Value: enabled
+
   IntegrationTestRunnerTaskDefinition:
     Condition: DevEnvironment
     Type: AWS::ECS::TaskDefinition
@@ -1897,6 +1898,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
+
   IntegrationTestRunnerTaskRole:
     Condition: DevEnvironment
     Type: AWS::IAM::Role
@@ -2050,6 +2052,7 @@ Resources:
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
+
   IntegrationTestRunnerTaskExecutionRole:
     Condition: DevEnvironment
     Type: AWS::IAM::Role
@@ -2074,11 +2077,69 @@ Resources:
                 Action:
                   - logs:CreateLogGroup
                 Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*'
+        - PolicyName: PullFromEcr
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: !GetAtt EcrEncryptionKey.Arn
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
+  IntegrationTestsRepository:
+    Condition: DevEnvironment
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub '${AWS::StackName}-integration-test-repository'
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      ImageTagMutability: IMMUTABLE
+      EncryptionConfiguration:
+        EncryptionType: KMS
+        KmsKey: !GetAtt EcrEncryptionKey.Arn
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep only the last 5 images",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 5
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+
+  EcrEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS key for ECR repository encryption
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowRootAccountFullAccess
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: '*'
+
+  EcrEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/ecr-integration-tests
+      TargetKeyId: !Ref EcrEncryptionKey
   ##############################
   # End: Development resources #
   ##############################

--- a/template.yaml
+++ b/template.yaml
@@ -1890,8 +1890,8 @@ Resources:
               Value: !Sub '${AWS::Region}'
             - Name: $TEST_ENVIRONMENT
               Value: 'dev'
-      Cpu: 1024
-      Memory: 2048
+      Cpu: 4096 # 4 CPUs
+      Memory: 8192
       TaskRoleArn: !GetAtt IntegrationTestRunnerTaskRole.Arn
       ExecutionRoleArn: !GetAtt IntegrationTestRunnerTaskExecutionRole.Arn
       Family: !Sub '${AWS::StackName}-integration-test-runner'

--- a/template.yaml
+++ b/template.yaml
@@ -2040,6 +2040,7 @@ Resources:
                   - kms:DescribeKey
                   - kms:GetPublicKey
                   - kms:Decrypt
+                  - kms:Encrypt
                   - kms:GenerateDataKey
                   - kms:Verify
                 Resource:

--- a/template.yaml
+++ b/template.yaml
@@ -1342,7 +1342,7 @@ Resources:
               - '{{resolve:ssm:SqsKmsKeyArn}}'
 
   ############################
-  # End: SNS DLQ Resouces   #
+  # End: SNS DLQ Resources   #
   ############################
 
   AuditMessageDeliveryStreamPolicy:
@@ -1376,6 +1376,16 @@ Resources:
               - logs:CreateLogStream
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+              - kms:CreateGrant
+            Resource:
+              - '{{resolve:ssm:FirehoseKmsKeyArn}}'
+            Condition:
+              Bool:
+                kms:GrantIsForAWSResource: true
 
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role

--- a/template.yaml
+++ b/template.yaml
@@ -1373,6 +1373,16 @@ Resources:
               - logs:CreateLogStream
             Resource:
               - !GetAtt AuditMessageDeliveryStreamLogs.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+              - kms:CreateGrant
+            Resource:
+              - '{{resolve:ssm:FirehoseKmsKeyArn}}'
+            Condition:
+              Bool:
+                kms:GrantIsForAWSResource: true
 
   AuditMessageDeliveryStreamRole:
     Type: AWS::IAM::Role

--- a/template.yaml
+++ b/template.yaml
@@ -1957,6 +1957,11 @@ Resources:
                   - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/acceptance-tests/*'
                 Effect: Allow
               - Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*'
+                Effect: Allow
+              - Action:
                   - secretsmanager:CancelRotateSecret
                   - secretsmanager:GetSecretValue
                   - secretsmanager:RotateSecret

--- a/tests/integrationTests/vitest.config.integration.ts
+++ b/tests/integrationTests/vitest.config.integration.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     include: ['**/tests/integrationTests/testSuites/*.spec.ts'],
     testTimeout: 300000,
-    setupFiles: ['./tests/support/setup/setup.ts'],
+    setupFiles: ['./tests/support/logger.ts', './tests/support/setup/setup.ts'],
     hookTimeout: 300000,
     pool: 'forks'
   }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,7 +10,10 @@
 # in the Dockerfile.
 cd /test-app || exit 1
 
-if [ "$TEST_ENVIRONMENT" == "build" ]; then
+if [ "$TEST_ENVIRONMENT" == "dev" ]; then
+  npm run test:integration
+  TESTS_EXIT_CODE=$?
+elif  [ "$TEST_ENVIRONMENT" == "build" ]; then
   npm run test:integration
   TESTS_EXIT_CODE=$?
 elif [ "$TEST_ENVIRONMENT" == "staging" ]; then

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -11,7 +11,7 @@
 cd /test-app || exit 1
 
 if [ "$TEST_ENVIRONMENT" == "dev" ]; then
-  npm run test:integration
+  npm run test:integration -- --reporter=minimal --no-color
   TESTS_EXIT_CODE=$?
 elif  [ "$TEST_ENVIRONMENT" == "build" ]; then
   npm run test:integration

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,19 +10,22 @@
 # in the Dockerfile.
 cd /test-app || exit 1
 
-if [ "$TEST_ENVIRONMENT" == "dev" ]; then
-  npm run test:integration -- --reporter=minimal --no-color
-  TESTS_EXIT_CODE=$?
-elif  [ "$TEST_ENVIRONMENT" == "build" ]; then
-  npm run test:integration
-  TESTS_EXIT_CODE=$?
-elif [ "$TEST_ENVIRONMENT" == "staging" ]; then
-  npm run test:e2e
-  TESTS_EXIT_CODE=$?
-else
-  echo "No Test Environment Set"
-  exit 1
-fi
+export CI=true
+
+case "$TEST_ENVIRONMENT" in
+  dev|build)
+    npm run test:integration -- --no-color
+    TESTS_EXIT_CODE=$?
+    ;;
+  staging)
+    npm run test:e2e
+    TESTS_EXIT_CODE=$?
+    ;;
+  *)
+    echo "No Test Environment Set"
+    exit 1
+    ;;
+esac
 
 cp tests/integration-tests/reports/junit.xml $TEST_REPORT_ABSOLUTE_DIR/junit.xml
 exit $TESTS_EXIT_CODE

--- a/tests/support/logger.ts
+++ b/tests/support/logger.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
+export const logger = new Logger({
+  serviceName: 'integration-tests',
+  environment: process.env.TEST_ENVIRONMENT,
+  logLevel: 'DEBUG'
+})
+
+process.on('uncaughtException', (err) => {
+  logger.error('Uncaught exception', err)
+  process.exit(1)
+})
+
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled rejection', reason as Error)
+  process.exit(1)
+})

--- a/tests/support/setup/setup.ts
+++ b/tests/support/setup/setup.ts
@@ -1,3 +1,4 @@
+import { logger } from '../logger'
 import { retrieveSsmParameterValue } from './retrieveSsmParameterValue'
 import { getOutputValue, retrieveStackOutputs } from './retrieveStackOutputs'
 
@@ -8,6 +9,8 @@ const setupFunction = async () => {
   try {
     process.env['AWS_REGION'] = region
     process.env['STACK_NAME'] = stack
+
+    logger.info('Starting test setup', { stackName: stack })
 
     const stackOutputMappings = {
       AUDIT_MESSAGE_DELIMITER_FUNCTION_NAME:
@@ -27,7 +30,7 @@ const setupFunction = async () => {
     await setEnvVarsFromStackOutputs(stack, stackOutputMappings)
     await setEnvVarsFromSsm(ssmMappings)
   } catch (error) {
-    console.error('Setup error:', error)
+    logger.error('Setup error', error as Error)
     throw error
   }
 }

--- a/tests/support/utils/aws/lambda/invokeLambda.ts
+++ b/tests/support/utils/aws/lambda/invokeLambda.ts
@@ -24,6 +24,7 @@ export const invokeLambdaFunction = async (
       `Lambda Error in function ${functionName}: ${resultPayload.errorType} - ${resultPayload.errorMessage}`
     )
   }
+  return resultPayload
 }
 
 const jsonToUint8Array = (json: unknown): Uint8Array => {

--- a/tests/support/utils/aws/lambda/invokeLambda.ts
+++ b/tests/support/utils/aws/lambda/invokeLambda.ts
@@ -2,6 +2,12 @@ import { getEnv } from '../../../../../common/utils/helpers/getEnv'
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda'
 import { TextEncoder, TextDecoder } from 'node:util'
 
+interface LambdaResult {
+  errorType?: string
+  errorMessage?: string
+  trace?: string[]
+}
+
 export const invokeLambdaFunction = async (
   functionName: string,
   payload: unknown
@@ -11,11 +17,12 @@ export const invokeLambdaFunction = async (
     FunctionName: functionName,
     Payload: jsonToUint8Array(payload)
   }
-  try {
-    const result = await client.send(new InvokeCommand(input))
-    return uint8ArrayToJson(result.Payload)
-  } catch (error) {
-    console.log('error', error)
+  const result = await client.send(new InvokeCommand(input))
+  const resultPayload = uint8ArrayToJson(result.Payload) as LambdaResult
+  if (resultPayload?.errorType) {
+    throw new Error(
+      `Lambda Error in function ${functionName}: ${resultPayload.errorType} - ${resultPayload.errorMessage}`
+    )
   }
 }
 

--- a/tests/support/utils/aws/s3/getAuditEvent.ts
+++ b/tests/support/utils/aws/s3/getAuditEvent.ts
@@ -38,7 +38,7 @@ export const getAuditEvent = async (
   } else {
     retryCount++
     if (retryCount > maxRetries) {
-      throw new Error('Could not find event in s3 bucket')
+      throw new Error(`Could not find event in s3 bucket ${bucket}`)
     } else {
       console.log(`Waiting for event data in bucket... ${retryCount} attempts`)
       await pause(exponentialBackoff(retryCount, 2))


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-3036
- **Semantic Version**: minor
- **Documentation Link(s)**: 
  - https://govukverify.atlassian.net/wiki/spaces/TMA/pages/6768132132/DPT-3036+-+Running+integration+tests+before+code+review

## :bulb: Description

This adds a GitHub action and AWS resources to upload the test docker image to the dev environment and run the integration tests against a feature branch

## :sparkles: Changes Made

New: GitHub Actions workflow to run integration tests (run-integration-tests.yaml)

  - Triggers after "Build, Test and Package" workflow completes on feature/** branches, or manually via workflow_dispatch
  - Derives the stack name from the branch name using the same algorithm as the deploy workflow
  - Builds and pushes a test container image to ECR, tagged with the commit SHA (immutable tags)
  - Signs the image with Cosign using KMS
  - Skips the image build if the tag already exists in ECR (faster re-runs)
  - Registers a new ECS task definition revision with the correct image
  - Runs the integration tests as a Fargate ECS task against the feature branch's CloudFormation stack
  - Waits for the task to complete and fails the workflow if tests fail

  CloudFormation template (template.yaml)

  - ECR repository for integration test images (KMS encrypted, immutable tags, lifecycle policy)
  - ECS Fargate cluster and task definition for running integration tests
  - Container signing key (asymmetric KMS key for Cosign)
  - ECR encryption key (symmetric KMS key for repository encryption)
  - ECS task role with permissions for: CloudFormation, SSM, Secrets Manager, DynamoDB, S3, SQS, SNS, KMS, CloudWatch Logs, Lambda invoke, API Gateway, ACM-PCA
  - ECS task execution role with permissions to pull from ECR and write logs
  - Fix: Firehose KMS policy — split the GrantIsForAWSResource condition to only apply to kms:CreateGrant, not to Decrypt/Encrypt/GenerateDataKey (was preventing Firehose from encrypting records)
  - S3 permissions for the test runner to read/write stack buckets

  Test infrastructure changes

  - tests/support/logger.ts — Structured JSON logging using Powertools Logger (single-line errors in CloudWatch)
  - tests/support/setup/setup.ts — Uses structured logger instead of console.error
  - tests/integrationTests/vitest.config.integration.ts — Added logger as a setup file
  - tests/run-tests.sh — Refactored to use case statement
  - tests/support/utils/aws/lambda/invokeLambda.ts — Improved error visibility

  Other

  - .gitignore — Added .venv
  - Fixed S3 key rotation Lambda permissions for listing bucket contents

## :test_tube: Testing Instructions/Notes

Check the running of the action as part of the code review

## :memo: Additional Notes

This is part of the Quality Gates initiative designed to improve the robustness and quality of all GDS Products. 